### PR TITLE
Removing incremental ids from pivots and fixing bug.

### DIFF
--- a/database/migrations/2016_02_17_175347_create_waiting_rooms_table.php
+++ b/database/migrations/2016_02_17_175347_create_waiting_rooms_table.php
@@ -29,6 +29,6 @@ class CreateWaitingRoomsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('waiting_room');
+        Schema::drop('waiting_rooms');
     }
 }

--- a/database/migrations/2016_02_17_175810_create_competition_user_table.php
+++ b/database/migrations/2016_02_17_175810_create_competition_user_table.php
@@ -13,7 +13,6 @@ class CreateCompetitionUserTable extends Migration
     public function up()
     {
         Schema::create('competition_user', function (Blueprint $table) {
-            $table->increments('id');
             $table->integer('competition_id')->unsigned()->index();
             $table->foreign('competition_id')->references('id')->on('competitions');
             $table->string('user_id')->index();

--- a/database/migrations/2016_02_17_195543_create_user_waiting_room_table.php
+++ b/database/migrations/2016_02_17_195543_create_user_waiting_room_table.php
@@ -13,7 +13,6 @@ class CreateUserWaitingRoomTable extends Migration
     public function up()
     {
         Schema::create('user_waiting_room', function (Blueprint $table) {
-            $table->increments('id');
             $table->string('user_id')->index();
             $table->foreign('user_id')->references('id')->on('users');
             $table->integer('waiting_room_id')->unsigned()->index();


### PR DESCRIPTION
#### What's this PR do?
This PR does a quick update to remove the incremental id column on the pivot tables since they're unnecessary, and fixes a typo on `down()` method for the `waiting_rooms` table.

---
@angaither @sbsmith86 

cc: @DFurnes 