### PR TITLE
Adds validation messages appropriate to the Northstar response.

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,10 +4,10 @@ namespace Gladiator\Exceptions;
 
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Validation\ValidationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Symfony\Component\HttpKernel\Exception\HttpException;
-use Illuminate\Foundation\Validation\ValidationException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class Handler extends ExceptionHandler
 {
@@ -45,6 +45,10 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $e)
     {
+        if ($e instanceof ValidationException) {
+            return redirect()->back()->withInput($request->input())->withErrors($e->errors());
+        }
+
         return parent::render($request, $e);
     }
 }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,9 +4,9 @@ namespace Gladiator\Exceptions;
 
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Contracts\Validation\ValidationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Foundation\Validation\ValidationException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class Handler extends ExceptionHandler
@@ -46,7 +46,7 @@ class Handler extends ExceptionHandler
     public function render($request, Exception $e)
     {
         if ($e instanceof ValidationException) {
-            return redirect()->back()->withInput($request->input())->withErrors($e->errors());
+            return redirect()->back()->withInput($request->input())->withErrors($e->validator->getMessages());
         }
 
         return parent::render($request, $e);

--- a/app/Services/RestApiClient.php
+++ b/app/Services/RestApiClient.php
@@ -4,6 +4,8 @@ namespace Gladiator\Services;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
+use Illuminate\Support\MessageBag;
+use Illuminate\Contracts\Validation\ValidationException;
 
 class RestApiClient
 {
@@ -56,7 +58,7 @@ class RestApiClient
             'query' => $query,
         ]);
 
-        return is_null($response) ? null : $this->getJson($response);
+        return is_null($response) ? null : $this->getJson($response)->data;
     }
 
     /**
@@ -72,7 +74,7 @@ class RestApiClient
             'body' => $this->makeJson($body),
         ]);
 
-        return is_null($response) ? false : $this->getJson($response);
+        return is_null($response) ? false : $this->getJson($response)->data;
     }
 
     /**
@@ -97,7 +99,7 @@ class RestApiClient
      */
     public function getJson($response, $asArray = false)
     {
-        return json_decode($response->getBody(), $asArray)->data;
+        return json_decode($response->getBody(), $asArray);
     }
 
     /**
@@ -124,15 +126,33 @@ class RestApiClient
         try {
             return $this->client->request($method, $path, $options);
         } catch (RequestException $error) {
+            $response = $this->getJson($error->getResponse());
+
             if ($error->getCode() === 404) {
-                // fill out error bag for showing errors to user
+                $messages = $this->setMessages($response->error);
+
+                // @TODO: maybe abort to 404 page?
                 return;
             }
 
             if ($error->getCode() === 401) {
-                // fill out error bag for showing errors to user
-                return;
+                $messages = $this->setMessages($response->error);
+
+                throw new ValidationException($messages);
             }
+
+            throw new HttpException(500, 'Northstar returned an error for that request.');
         }
+    }
+
+    /**
+     * Set any erorr message within a MessageBag.
+     *
+     * @param object  $error
+     */
+    protected function setMessages($error)
+    {
+        // @TODO: may eventually need to handle an array of errors.
+        return (new MessageBag)->add($error->code, $error->message);
     }
 }

--- a/app/Services/RestApiClient.php
+++ b/app/Services/RestApiClient.php
@@ -5,7 +5,7 @@ namespace Gladiator\Services;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use Illuminate\Support\MessageBag;
-use Illuminate\Contracts\Validation\ValidationException;
+use Illuminate\Foundation\Validation\ValidationException;
 
 class RestApiClient
 {

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -18,12 +18,12 @@
 
                     <div class="form-item -padded">
                         <label class="field-label" for="email">Email</label>
-                        <input type="text" name="email" id="email" class="text-field" placeholder="kallark&#64;dosomething.org" required>
+                        <input type="text" name="email" id="email" class="text-field" placeholder="kallark&#64;dosomething.org">
                     </div>
 
                     <div class="form-item -padded">
                         <label class="field-label" for="password">Password</label>
-                        <input type="password" name="password" id="password" class="text-field" placeholder="••••••" required>
+                        <input type="password" name="password" id="password" class="text-field" placeholder="••••••">
                     </div>
 
                     <input type="submit" class="button" value="Log In" />


### PR DESCRIPTION
#### What's this PR do?
This PR updates the validation so it can send the custom error messages that Northstar responds with to properly indicate what the issue was with the authentication. This can also be customized further depending on additional error responses that Northstar can return with.

#### Where should the reviewer start?
Start at the **RestApiClient.php** file and follow the method trail from there!

#### How should this be manually tested?
Try logging in with bogus infoz and you should see error messages.

When email is correct but password is wrong, should say `Invalid credentials.`.

#### What are the relevant tickets?
#17 

---
@angaither @sbsmith86 @deadlybutter 