### PR TITLE
User static methods

### DIFF
--- a/app/Console/Commands/AddUser.php
+++ b/app/Console/Commands/AddUser.php
@@ -35,13 +35,13 @@ class AddUser extends Command
             return $this->comment(PHP_EOL . $email . ' is invalid. Admin or Staff require a DoSomething.org email.' . PHP_EOL);
         }
 
-        $northstarUser = findNorthstarAccount($email, 'email');
+        $northstarUser = User::hasNorthstarAccount('email', $email);
 
         if (is_null($northstarUser)) {
             return $this->comment(PHP_EOL . 'No user found on Northstar with email: ' . $email . '. Create an account at https://dosomething.org.' . PHP_EOL);
         }
 
-        $gladiatorUser = findGladiatorAccount($northstarUser->id);
+        $gladiatorUser = User::find($northstarUser->id);
 
         if (is_null($gladiatorUser)) {
             $user = new User;

--- a/app/Console/Commands/AddUser.php
+++ b/app/Console/Commands/AddUser.php
@@ -35,7 +35,6 @@ class AddUser extends Command
             return $this->comment(PHP_EOL . $email . ' is invalid. Admin or Staff require a DoSomething.org email.' . PHP_EOL);
         }
 
-
         $northstarUser = findNorthstarAccount($email, 'email');
 
         if (is_null($northstarUser)) {

--- a/app/Console/Commands/AddUser.php
+++ b/app/Console/Commands/AddUser.php
@@ -3,7 +3,6 @@
 namespace Gladiator\Console\Commands;
 
 use Gladiator\Models\User;
-use Gladiator\Services\Northstar\Northstar;
 use Illuminate\Console\Command;
 
 class AddUser extends Command
@@ -23,25 +22,6 @@ class AddUser extends Command
     protected $description = 'Adds a new authorized user from Northstar';
 
     /**
-     * The northstar service.
-     *
-     * @var Northstar
-     */
-    protected $northstar;
-
-    /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct(Northstar $northstar)
-    {
-        parent::__construct();
-
-        $this->northstar = $northstar;
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed
@@ -51,13 +31,18 @@ class AddUser extends Command
         $email = $this->argument('email');
         $role = $this->option('role');
 
-        $northstarUser = $this->northstar->getUser($email);
+        if (! matchEmailDomain($email)) {
+            return $this->comment(PHP_EOL . $email . ' is invalid. Admin or Staff require a DoSomething.org email.' . PHP_EOL);
+        }
+
+
+        $northstarUser = findNorthstarAccount($email, 'email');
 
         if (is_null($northstarUser)) {
             return $this->comment(PHP_EOL . 'No user found on Northstar with email: ' . $email . '. Create an account at https://dosomething.org.' . PHP_EOL);
         }
 
-        $gladiatorUser = User::find($northstarUser->id);
+        $gladiatorUser = findGladiatorAccount($northstarUser->id);
 
         if (is_null($gladiatorUser)) {
             $user = new User;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -23,7 +23,7 @@ class User extends BaseUser
     ];
 
     /**
-     * A User belongs to many Competitions
+     * A User belongs to many Competitions.
      */
     public function competitions()
     {
@@ -38,6 +38,12 @@ class User extends BaseUser
         return $this->belongsToMany(WaitingRoom::class);
     }
 
+    /**
+     * Check if user has specified role.
+     *
+     * @param  string|array
+     * @return boolean
+     */
     public function hasRole($roles)
     {
         $roles = is_array($roles) ? $roles : [$roles];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace Gladiator\Models;
 
+use Gladiator\Services\Northstar\Exceptions\NorthstarUserNotFoundException;
 use Illuminate\Foundation\Auth\User as BaseUser;
 
 class User extends BaseUser
@@ -49,5 +50,40 @@ class User extends BaseUser
         $roles = is_array($roles) ? $roles : [$roles];
 
         return in_array($this->role, $roles);
+    }
+
+    /**
+     * @param  string  $type
+     * @param  string  $id
+     * @return \Gladiator\Models\User|string
+     * @throws \Gladiator\Services\Northstar\Exceptions\NorthstarUserNotFoundException
+     */
+    public static function hasAccountInSystem($type, $id)
+    {
+        $northstarUser = static::hasNorthstarAccount($type, $id);
+
+        if (! $northstarUser) {
+            throw new NorthstarUserNotFoundException;
+        }
+
+        $user = static::find($northstarUser->id);
+
+        if (! $user) {
+            return $northstarUser->id;
+        }
+
+        return $user;
+    }
+
+    /**
+     * @param  string  $type
+     * @param  string  $id
+     * @return object|null
+     */
+    public static function hasNorthstarAccount($type, $id)
+    {
+        $northstar = app('northstar');
+
+        return $northstar->getUser($type, $id);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -42,7 +42,7 @@ class User extends BaseUser
      * Check if user has specified role.
      *
      * @param  string|array
-     * @return boolean
+     * @return bool
      */
     public function hasRole($roles)
     {

--- a/app/Providers/GladiatorUserProvider.php
+++ b/app/Providers/GladiatorUserProvider.php
@@ -19,7 +19,7 @@ class GladiatorUserProvider extends EloquentUserProvider implements UserProvider
     {
         $northstar = app(Northstar::class);
 
-        $user = $northstar->getUser($credentials['email']);
+        $user = $northstar->getUser('email', $credentials['email']);
 
         if (! $user) {
             return;

--- a/app/Providers/NorthstarServiceProvider.php
+++ b/app/Providers/NorthstarServiceProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Gladiator\Providers;
+
+use Gladiator\Services\Northstar\Northstar;
+use Illuminate\Support\ServiceProvider;
+
+class NorthstarServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap the application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        //
+    }
+
+    /**
+     * Register the application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->singleton('northstar', function ($app) {
+            return new Northstar();
+        });
+    }
+}

--- a/app/Services/Northstar/Exceptions/NorthstarUserNotFoundException.php
+++ b/app/Services/Northstar/Exceptions/NorthstarUserNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Gladiator\Services\Northstar\Exceptions;
+
+use Exception;
+
+class NorthstarUserNotFoundException extends Exception
+{
+    /**
+     * Make a new Northstar User exception.
+     */
+    public function __construct()
+    {
+        parent::__construct('Northstar user was not found.');
+    }
+}

--- a/app/Services/Northstar/Northstar.php
+++ b/app/Services/Northstar/Northstar.php
@@ -23,11 +23,11 @@ class Northstar extends RestApiClient
     /**
      * Send a GET request to return a user with the specified id.
      *
-     * @param  string  $id
      * @param  string  $type
+     * @param  string  $id
      * @return object
      */
-    public function getUser($id, $type = 'email')
+    public function getUser($type, $id)
     {
         $response = $this->get('users/' . $type . '/' . $id);
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,8 +1,5 @@
 <?php
 
-use Gladiator\Models\User;
-use Gladiator\Services\Northstar\Exceptions\NorthstarUserNotFoundException;
-
 /**
  * Match supplied email against a specific domain or default domain.
  *
@@ -19,48 +16,4 @@ function matchEmailDomain($email, $domain = 'dosomething.org')
     }
 
     return false;
-}
-
-/**
- * @param  string  $id
- * @param  string  $email
- * @return \Gladiator\Models\User|string
- * @throws \Gladiator\Services\Northstar\Exceptions\NorthstarUserNotFoundException
- */
-function findUserAccountInSystem($id, $type = 'email')
-{
-    $northstarUser = findNorthstarAccount($id, $type);
-
-    if (! $northstarUser) {
-        throw new NorthstarUserNotFoundException;
-    }
-
-    $gladiatorUser = findGladiatorAccount($northstarUser->id);
-
-    if (! $gladiatorUser) {
-        return $northstarUser->id;
-    }
-
-    return $gladiatorUser;
-}
-
-/**
- * @param  string  $id
- * @return \Gladiator\Models\User|null
- */
-function findGladiatorAccount($id)
-{
-    return User::find($id);
-}
-
-/**
- * @param  string  $id
- * @param  string  $type
- * @return object|null
- */
-function findNorthstarAccount($id, $type = 'email')
-{
-    $northstar = app('northstar');
-
-    return $northstar->getUser($id, $type);
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,0 +1,74 @@
+<?php
+
+use Gladiator\Models\User;
+use Gladiator\Services\Northstar\Exceptions\NorthstarUserNotFoundException;
+
+if (! function_exists('matchEmailDomain')) {
+    /**
+     * Match supplied email against a specific domain or default domain.
+     *
+     * @param  string  $email
+     * @param  string  $domain
+     * @return boolean
+     */
+    function matchEmailDomain($email, $domain = 'dosomething.org')
+    {
+        $pieces = explode('@', $email);
+
+        if (is_array($pieces) && count($pieces) > 1) {
+            return $pieces[1] === $domain ? true : false;
+        }
+
+        return false;
+    }
+}
+
+if (! function_exists('findUserInSystem')) {
+    /**
+     * @param  string  $id
+     * @param  string  $email
+     * @return \Gladiator\Models\User|string
+     * @throws \Gladiator\Services\Northstar\Exceptions\NorthstarUserNotFoundException
+     */
+    function findUserInSystem($id, $type = 'email')
+    {
+        $northstarUser = findNorthstarAccount($id, $type);
+
+        if (! $northstarUser) {
+            throw new NorthstarUserNotFoundException;
+        }
+
+        $gladiatorUser = findGladiatorAccount($northstarUser->id);
+
+        if (! $gladiatorUser) {
+            return $northstarUser->id;
+        }
+
+        return $gladiatorUser;
+    }
+}
+
+if (! function_exists('findGladiatorAccount')) {
+    /**
+     * @param  string  $id
+     * @return \Gladiator\Models\User|null
+     */
+    function findGladiatorAccount($id)
+    {
+        return User::find($id);
+    }
+}
+
+if (! function_exists('findNorthstarAccount')) {
+    /**
+     * @param  string  $id
+     * @param  string  $type
+     * @return object|null
+     */
+    function findNorthstarAccount($id, $type = 'email')
+    {
+        $northstar = app('northstar');
+
+        return $northstar->getUser($id, $type);
+    }
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -3,72 +3,64 @@
 use Gladiator\Models\User;
 use Gladiator\Services\Northstar\Exceptions\NorthstarUserNotFoundException;
 
-if (! function_exists('matchEmailDomain')) {
-    /**
-     * Match supplied email against a specific domain or default domain.
-     *
-     * @param  string  $email
-     * @param  string  $domain
-     * @return bool
-     */
-    function matchEmailDomain($email, $domain = 'dosomething.org')
-    {
-        $pieces = explode('@', $email);
+/**
+ * Match supplied email against a specific domain or default domain.
+ *
+ * @param  string  $email
+ * @param  string  $domain
+ * @return bool
+ */
+function matchEmailDomain($email, $domain = 'dosomething.org')
+{
+    $pieces = explode('@', $email);
 
-        if (is_array($pieces) && count($pieces) > 1) {
-            return $pieces[1] === $domain ? true : false;
-        }
-
-        return false;
+    if (is_array($pieces) && count($pieces) > 1) {
+        return $pieces[1] === $domain ? true : false;
     }
+
+    return false;
 }
 
-if (! function_exists('findUserAccountInSystem')) {
-    /**
-     * @param  string  $id
-     * @param  string  $email
-     * @return \Gladiator\Models\User|string
-     * @throws \Gladiator\Services\Northstar\Exceptions\NorthstarUserNotFoundException
-     */
-    function findUserAccountInSystem($id, $type = 'email')
-    {
-        $northstarUser = findNorthstarAccount($id, $type);
+/**
+ * @param  string  $id
+ * @param  string  $email
+ * @return \Gladiator\Models\User|string
+ * @throws \Gladiator\Services\Northstar\Exceptions\NorthstarUserNotFoundException
+ */
+function findUserAccountInSystem($id, $type = 'email')
+{
+    $northstarUser = findNorthstarAccount($id, $type);
 
-        if (! $northstarUser) {
-            throw new NorthstarUserNotFoundException;
-        }
-
-        $gladiatorUser = findGladiatorAccount($northstarUser->id);
-
-        if (! $gladiatorUser) {
-            return $northstarUser->id;
-        }
-
-        return $gladiatorUser;
+    if (! $northstarUser) {
+        throw new NorthstarUserNotFoundException;
     }
+
+    $gladiatorUser = findGladiatorAccount($northstarUser->id);
+
+    if (! $gladiatorUser) {
+        return $northstarUser->id;
+    }
+
+    return $gladiatorUser;
 }
 
-if (! function_exists('findGladiatorAccount')) {
-    /**
-     * @param  string  $id
-     * @return \Gladiator\Models\User|null
-     */
-    function findGladiatorAccount($id)
-    {
-        return User::find($id);
-    }
+/**
+ * @param  string  $id
+ * @return \Gladiator\Models\User|null
+ */
+function findGladiatorAccount($id)
+{
+    return User::find($id);
 }
 
-if (! function_exists('findNorthstarAccount')) {
-    /**
-     * @param  string  $id
-     * @param  string  $type
-     * @return object|null
-     */
-    function findNorthstarAccount($id, $type = 'email')
-    {
-        $northstar = app('northstar');
+/**
+ * @param  string  $id
+ * @param  string  $type
+ * @return object|null
+ */
+function findNorthstarAccount($id, $type = 'email')
+{
+    $northstar = app('northstar');
 
-        return $northstar->getUser($id, $type);
-    }
+    return $northstar->getUser($id, $type);
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -9,7 +9,7 @@ if (! function_exists('matchEmailDomain')) {
      *
      * @param  string  $email
      * @param  string  $domain
-     * @return boolean
+     * @return bool
      */
     function matchEmailDomain($email, $domain = 'dosomething.org')
     {
@@ -23,14 +23,14 @@ if (! function_exists('matchEmailDomain')) {
     }
 }
 
-if (! function_exists('findUserInSystem')) {
+if (! function_exists('findUserAccountInSystem')) {
     /**
      * @param  string  $id
      * @param  string  $email
      * @return \Gladiator\Models\User|string
      * @throws \Gladiator\Services\Northstar\Exceptions\NorthstarUserNotFoundException
      */
-    function findUserInSystem($id, $type = 'email')
+    function findUserAccountInSystem($id, $type = 'email')
     {
         $northstarUser = findNorthstarAccount($id, $type);
 

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
             "database",
             "app/Models"
         ],
+        "files": [
+            "app/helpers.php"
+        ],
         "psr-4": {
             "Gladiator\\": "app/"
         }

--- a/config/app.php
+++ b/config/app.php
@@ -154,6 +154,7 @@ return [
         Gladiator\Providers\AppServiceProvider::class,
         Gladiator\Providers\AuthServiceProvider::class,
         Gladiator\Providers\EventServiceProvider::class,
+        Gladiator\Providers\NorthstarServiceProvider::class,
         Gladiator\Providers\RouteServiceProvider::class,
 
         Collective\Html\HtmlServiceProvider::class,

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,11 @@
+#### What's this PR do?
+tell us, what have you changed?
+
+#### How should this be manually tested?
+tell us, how can we check that it works?
+
+#### Any background context you want to provide?
+what else?
+
+#### What are the relevant tickets?
+Fixes #WHAT


### PR DESCRIPTION
#### What's this PR do?
This PR adds some static helper method to help deal with handling finding a user within the DS system, whether they're in Northstar, in Northstar but not Gladiator, or in both Northstar and in Gladiator. The aim is to create some static methods that can be called that handle a lot of the User lookup throughout the system and help avoid repeated code throughout the app.

here's an example of how you could use the helper function:
```php
$user = Gladiator\Models\User::hasAccountInSystem('email', 'dlorenzo@dosomething.org');

if ($user instanceof Gladiator\Models\User) {
  // We found the user in system as Gladiator user, so lets just add them to a WaitingRoom...
}

// User was found on Northstar (since no exception thrown), but not on Gladiator.
// All we get is a NS id string, lets save the id and add them as a new user to Gladiator!
$northstarId = $user->id;

$user = new User;
$user->id = $northstarId;
$user->save();
```

#### How should this be manually tested?
Um, best way to test for now is to set up a test route an try calling the static methods with appropriate info.

#### Any background context you want to provide?
In #35 I added these as global helper functions since I didn't like them as methods on the User model, but I wasn't super convinced that was a good idea. After a bit of discussion in that PR, tried going the route of static methods as @DFurnes suggested and I definitely like it better!

Also @DFurnes I fixed up the order of the params on the `getUser()` NS method so it matches when I switch over to use the composer package :)

#### What are the relevant tickets?
Refs #22 
Refs #32 


--- 
@DFurnes @sbsmith86 @deadlybutter 