### PR TITLE
User CRUD via interface & API requests

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Gladiator\Http\Controllers\Api;
+
+use Gladiator\Repositories\UserRepository;
+use Gladiator\Http\Controllers\Controller;
+
+class UsersController extends Controller
+{
+
+    // @TODO: set up a UserRepository to handle a lot of the business logic
+    // that would be shared between the Web UsersController and Api UsersController
+
+
+    public function store()
+    {
+        // do stuff.
+    }
+}

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -7,10 +7,8 @@ use Gladiator\Http\Controllers\Controller;
 
 class UsersController extends Controller
 {
-
     // @TODO: set up a UserRepository to handle a lot of the business logic
     // that would be shared between the Web UsersController and Api UsersController
-
 
     public function store()
     {

--- a/app/Http/Controllers/CompetitionsController.php
+++ b/app/Http/Controllers/CompetitionsController.php
@@ -47,6 +47,7 @@ class CompetitionsController extends Controller
     public function store(CompetitionRequest $request)
     {
         Competition::create($request->all());
+
         return redirect()->route('competitions.index');
     }
 

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -85,8 +85,6 @@ class UsersController extends Controller
      */
     public function edit(User $user)
     {
-        dd($user);
-        // dd(app('request'));
         return view('users.edit', compact('user'));
     }
 
@@ -94,12 +92,15 @@ class UsersController extends Controller
      * Update the specified resource in storage.
      *
      * @param  Gladiator\Http\Requests\UserRequest  $request
-     * @param  int  $id
+     * @param  \Gladiator\Models\User  $user
      * @return \Illuminate\Http\Response
      */
-    public function update(UserRequest $request, $id)
+    public function update(UserRequest $request, $user)
     {
-        //
+        $user->role = $request->role;
+        $user->save();
+
+        return redirect()->route('users.index')->with('status', 'User has been updated!');
     }
 
     /**

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -2,9 +2,7 @@
 
 namespace Gladiator\Http\Controllers;
 
-use Illuminate\Http\Request;
 use Gladiator\Models\User;
-use Gladiator\Models\WaitingRoom;
 use Gladiator\Http\Requests\UserRequest;
 
 class UsersController extends Controller

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -2,10 +2,10 @@
 
 namespace Gladiator\Http\Controllers;
 
+use Illuminate\Http\Request;
 use Gladiator\Models\User;
 use Gladiator\Models\WaitingRoom;
 use Gladiator\Http\Requests\UserRequest;
-use Gladiator\Http\Controllers\Controller;
 
 class UsersController extends Controller
 {
@@ -39,8 +39,8 @@ class UsersController extends Controller
      */
     public function store(UserRequest $request)
     {
+        // dd($request->all());
         $account = User::hasAccountInSystem($request->type, $request->key);
-        // dd($account);
 
         if ($account instanceof User) {
             $user = $account;
@@ -48,6 +48,7 @@ class UsersController extends Controller
         else {
             $user = new User;
             $user->id = $account;
+            $user->role = $request->role;
             $user->save();
         }
 

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Gladiator\Http\Controllers;
+
+use Gladiator\Models\User;
+use Gladiator\Models\WaitingRoom;
+use Gladiator\Http\Requests\UserRequest;
+use Gladiator\Http\Controllers\Controller;
+
+class UsersController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        $users = User::all();
+
+        return view('users.index', compact('users'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        return view('users.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  Gladiator\Http\Requests\UserRequest  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(UserRequest $request)
+    {
+        $account = User::hasAccountInSystem($request->type, $request->key);
+        // dd($account);
+
+        if ($account instanceof User) {
+            $user = $account;
+        }
+        else {
+            $user = new User;
+            $user->id = $account;
+            $user->save();
+        }
+
+        if (isset($request->campaign_id) && isset($request->campaign_run_id)) {
+            $waitingRoom = WaitingRoom::where('campaign_id', '=', $request->campaign_id)
+                                          ->where('campaign_run_id', '=', $request->campaign_run_id)
+                                          ->firstOrFail();
+
+            $waitingRoom->users()->attach($user->id);
+
+            return 'user added to specified waiting room';
+        }
+
+        return redirect()->back()->with('status', 'User has been added!');
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  Gladiator\Http\Requests\UserRequest  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(UserRequest $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/app/Http/Requests/CompetitionRequest.php
+++ b/app/Http/Requests/CompetitionRequest.php
@@ -28,5 +28,4 @@ class CompetitionRequest extends Request
             'end_date' => 'required|date',
         ];
     }
-
 }

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Gladiator\Http\Requests;
+
+use Gladiator\Http\Requests\Request;
+
+class UserRequest extends Request
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        // @TODO: check authorization?
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'campaign_id' => 'numeric',
+            'campaign_run_id' => 'numeric',
+        ];
+    }
+}

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -25,6 +25,8 @@ class UserRequest extends Request
     public function rules()
     {
         return [
+            'key' => 'required',
+            'type' => 'required',
             'campaign_id' => 'numeric',
             'campaign_run_id' => 'numeric',
         ];

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -2,8 +2,6 @@
 
 namespace Gladiator\Http\Requests;
 
-use Gladiator\Http\Requests\Request;
-
 class UserRequest extends Request
 {
     /**

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -27,6 +27,7 @@ class UserRequest extends Request
         return [
             'key' => 'required',
             'type' => 'required',
+            'role' => 'required',
             'campaign_id' => 'numeric',
             'campaign_run_id' => 'numeric',
         ];

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -27,6 +27,7 @@ Route::group(['middleware' => ['web']], function () {
     Route::resource('competitions', 'CompetitionsController');
 
     // Users
+    Route::model('users', 'Gladiator\Models\User');
     Route::resource('users', 'UsersController');
 
     // Waiting rooms routes.

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -40,7 +40,7 @@ Route::group(['middleware' => ['web']], function () {
 
 Route::group(['prefix' => 'api/v1'], function () {
 
-    Route::get('/', function() {
+    Route::get('/', function () {
         return 'Gladiator API version 1';
     });
 

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -26,10 +26,27 @@ Route::group(['middleware' => ['web']], function () {
     Route::model('competitions', 'Gladiator\Models\Competition');
     Route::resource('competitions', 'CompetitionsController');
 
+    // Users
+    Route::resource('users', 'UsersController');
+
     // Waiting rooms routes.
     Route::get('waitingrooms/{waitingrooms}/split', 'WaitingRoomsController@showSplitForm')->name('split');
     Route::post('waitingrooms/{waitingrooms}/split', 'WaitingRoomsController@split')->name('split');
     Route::model('waitingrooms', 'Gladiator\Models\WaitingRoom');
     Route::resource('waitingrooms', 'WaitingRoomsController');
+
+});
+
+Route::group(['prefix' => 'api/v1'], function () {
+
+    Route::get('/', function() {
+        return 'Gladiator API version 1';
+    });
+
+    Route::get('users', function () {
+        return Gladiator\Models\User::all();
+    });
+
+    Route::post('users', 'UsersController@store');
 
 });

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -48,6 +48,6 @@ Route::group(['prefix' => 'api/v1'], function () {
         return Gladiator\Models\User::all();
     });
 
-    Route::post('users', 'UsersController@store');
+    Route::post('users', 'Api\UsersController@store');
 
 });

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -60,7 +60,7 @@ class User extends BaseUser
      */
     public function setRoleAttribute($value)
     {
-        $this->attributes['role'] = $value === 'member' ? null: $value;
+        $this->attributes['role'] = $value === 'member' ? null : $value;
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -53,6 +53,17 @@ class User extends BaseUser
     }
 
     /**
+     * Set the role for the user.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public function setRoleAttribute($value)
+    {
+        $this->attributes['role'] = $value === 'member' ? null: $value;
+    }
+
+    /**
      * @param  string  $type
      * @param  string  $id
      * @return \Gladiator\Models\User|string

--- a/app/Models/WaitingRoom.php
+++ b/app/Models/WaitingRoom.php
@@ -72,5 +72,4 @@ class WaitingRoom extends Model
             }
         }
     }
-
 }

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -1,0 +1,6 @@
+<?php
+
+class UserRepository
+{
+  // @TODO: Do the thing win the points. Shared User business logic goes here!
+}

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -2,5 +2,5 @@
 
 class UserRepository
 {
-  // @TODO: Do the thing win the points. Shared User business logic goes here!
+    // @TODO: Do the thing win the points. Shared User business logic goes here!
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,6 +1,17 @@
 <?php
 
 /**
+ * Check if the waiting room signup period ended.
+ *
+ * @param  date  $signupDate
+ * @return bool
+ */
+function hasSignupPeriodEnded($signupDate)
+{
+    return time() - (60 * 60 * 24) >= strtotime($signupDate);
+}
+
+/**
  * Match supplied email against a specific domain or default domain.
  *
  * @param  string  $email
@@ -16,9 +27,4 @@ function matchEmailDomain($email, $domain = 'dosomething.org')
     }
 
     return false;
-}
-
-function hasSignupPeriodEnded($signupDate)
-{
-    return time() - (60 * 60 * 24) >= strtotime($signupDate);
 }

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -5,13 +5,12 @@ $forge-path: "/assets/vendor/forge/assets/";
 @import "../../../node_modules/@dosomething/forge/scss/forge";
 
 // Local patterns
+@import "patterns/errors";
 @import "patterns/tables";
-
-.validation-error {
-  color: #ff4747;
-}
+@import "patterns/key-value";
 
 .container__split {
   display: inline-block;
   padding: 16px;
 }
+

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -1,4 +1,7 @@
-// Forge
+// Set up asset pipeline for Forge
+$forge-path: "/assets/vendor/forge/assets/";
+
+// Import Forge modules
 @import "../../../node_modules/@dosomething/forge/scss/forge";
 
 // Local patterns

--- a/resources/assets/sass/patterns/_errors.scss
+++ b/resources/assets/sass/patterns/_errors.scss
@@ -1,0 +1,3 @@
+.validation-error {
+  color: #ff4747;
+}

--- a/resources/assets/sass/patterns/_key-value.scss
+++ b/resources/assets/sass/patterns/_key-value.scss
@@ -1,0 +1,23 @@
+// @TODO: Will likely turn this into a more fleshed out pattern with definition alignment.
+
+.key-value {
+  @include clearfix;
+
+  margin-bottom: $section-spacing;
+
+  .heading + &,
+  p + & {
+    margin-top: $base-spacing;
+  }
+
+  dt {
+    clear: both;
+    font-weight: 700;
+    float: left;
+    padding-right: 12px;
+  }
+
+  dd {
+    float: left;
+  }
+}

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -17,7 +17,7 @@
                     </a>
                 </li>
                 <li>
-                    <a href="/">
+                    <a href="{{ URL::to('users') }}">
                         <strong class="navigation__title">Users</strong>
                         <span class="navigation__subtitle">Admins, Staff, Members</span>
                     </a>

--- a/resources/views/layouts/status.blade.php
+++ b/resources/views/layouts/status.blade.php
@@ -1,3 +1,3 @@
 @if (Session::has('status'))
-    <div>{{ Session::get('status') }}</div>
+    <div class="messages">{{ Session::get('status') }}</div>
 @endif

--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -1,0 +1,22 @@
+@extends('layouts.master')
+
+@section('main_content')
+
+    @include('layouts.header',[
+        'title' => 'Users',
+        'subtitle' => 'Add a new user'
+    ])
+
+    <div class="container">
+        <div class="wrapper">
+            <div class="container__block">
+                <form method="POST" action="/users">
+                    {{ csrf_field() }}
+
+                    @include('users.partials._form_users')
+                </form>
+            </div>
+        </div>
+    </div>
+
+@stop

--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -11,8 +11,6 @@
         <div class="wrapper">
             <div class="container__block">
                 <form method="POST" action="/users">
-                    {{ csrf_field() }}
-
                     @include('users.partials._form_users')
                 </form>
             </div>

--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -10,7 +10,7 @@
     <div class="container">
         <div class="wrapper">
             <div class="container__block">
-                <form method="POST" action="/users">
+                <form method="POST" action="{{ route('users.create') }}">
                     @include('users.partials._form_users')
                 </form>
             </div>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,0 +1,20 @@
+@extends('layouts.master')
+
+@section('main_content')
+
+    @include('layouts.header',[
+        'title' => 'Users',
+        'subtitle' => 'Edit user ' . $user->id
+    ])
+
+    <div class="container">
+        <div class="wrapper">
+            <div class="container__block">
+                <form method="POST" action="/users">
+                    @include('users.partials._form_users')
+                </form>
+            </div>
+        </div>
+    </div>
+
+@stop

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -10,7 +10,9 @@
     <div class="container">
         <div class="wrapper">
             <div class="container__block">
-                <form method="POST" action="/users">
+                <form method="POST" action="{{ route('users.update', $user->id) }}">
+                    {{ method_field('PATCH') }}
+
                     @include('users.partials._form_users')
                 </form>
             </div>

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -19,7 +19,7 @@
     @endif
 
     @if (count($staff) > 0)
-        @include('users.partials._table_users', ['users' => $staff, 'role' => 'Staffs'])
+        @include('users.partials._table_users', ['users' => $staff, 'role' => 'Staff'])
     @endif
 
     @if (count($contestants) > 0)

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts.master')
+
+@section('main_content')
+
+    @include('layouts.header',[
+        'title' => 'Users'
+    ])
+
+    <div class="container">
+        <div class="wrapper">
+            <div class="container__block">
+                <a class="button" href="{{ route('users.create') }}">Add User</a>
+            </div>
+        </div>
+    </div>
+
+    <div class="container">
+        <div class="wrapper">
+            <div class="container__block">
+                <table class="table">
+                    <thead>
+                        <tr class="table__header">
+                            <th class="table__cell">ID</th>
+                            <th class="table__cell">First Name</th>
+                            <th class="table__cell">Last Name</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($users as $user)
+                            <tr class="table__row">
+                                <td class="table__cell">{{ $user->id }}</td>
+                                <td class="table__cell">&hellip;</td>
+                                <td class="table__cell">&hellip;</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+@stop

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -14,29 +14,16 @@
         </div>
     </div>
 
-    <div class="container">
-        <div class="wrapper">
-            <div class="container__block">
-                <table class="table">
-                    <thead>
-                        <tr class="table__header">
-                            <th class="table__cell">ID</th>
-                            <th class="table__cell">First Name</th>
-                            <th class="table__cell">Last Name</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @foreach ($users as $user)
-                            <tr class="table__row">
-                                <td class="table__cell">{{ $user->id }}</td>
-                                <td class="table__cell">&hellip;</td>
-                                <td class="table__cell">&hellip;</td>
-                            </tr>
-                        @endforeach
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </div>
+    @if (count($admins) > 0)
+        @include('users.partials._table_users', ['users' => $admins, 'role' => 'Admins'])
+    @endif
+
+    @if (count($staff) > 0)
+        @include('users.partials._table_users', ['users' => $staff, 'role' => 'Staffs'])
+    @endif
+
+    @if (count($contestants) > 0)
+        @include('users.partials._table_users', ['users' => $contestants, 'role' => 'Contestants'])
+    @endif
 
 @stop

--- a/resources/views/users/partials/_form_users.blade.php
+++ b/resources/views/users/partials/_form_users.blade.php
@@ -4,16 +4,16 @@
 
 <div class="form-item -padded">
     <label class="field-label" for="key">User identification key:</label>
-    <input type="text" name="key" id="key" class="text-field" placeholder="Email, Mobile Phone Number, Northstar ID or Phoenix ID" value="{{ old('id') }}"/>
+    <input type="text" name="key" id="key" class="text-field" placeholder="Email, Mobile Phone Number, Northstar ID or Phoenix ID" value="{{ $user->id or old('key') }}"/>
 </div>
 
 <div class="form-item -padded">
     <label class="field-label" for="type">Select user key type:</label>
     <div class="select">
         <select name="type">
-            <option value="email" selected>Email</option>
+            <option value="email" {{! isset($user->id) ? 'selected' : '' }}>Email</option>
             <option value="mobile">Mobile Phone Number</option>
-            <option value="id">Northstar ID</option>
+            <option value="id" {{ isset($user->id) ? 'selected' : '' }}>Northstar ID</option>
             <option value="drupal_id">Phoenix ID</option>
         </select>
     </div>
@@ -22,17 +22,17 @@
 <div class="form-item -padded">
     <p class="field-label">Specify a role for this user:</p>
     <label class="option -radio">
-        <input checked type="radio" name="role" id="member" value="member">
+        <input type="radio" name="role" id="member" value="member" {{ isset($user->role) && $user->role === 'member' ? 'checked' : '' }}>
         <span class="option__indicator"></span>
         <span>Member</span>
     </label>
     <label class="option -radio">
-        <input type="radio" name="role" id="staff" value="staff">
+        <input type="radio" name="role" id="staff" value="staff" {{ isset($user->role) && $user->role === 'staff' ? 'checked' : '' }}>
         <span class="option__indicator"></span>
         <span>Staff</span>
     </label>
     <label class="option -radio">
-        <input type="radio" name="role" id="admin" value="admin">
+        <input type="radio" name="role" id="admin" value="admin" {{ isset($user->role) && $user->role === 'admin' ? 'checked' : '' }}>
         <span class="option__indicator"></span>
         <span>Admin</span>
     </label>

--- a/resources/views/users/partials/_form_users.blade.php
+++ b/resources/views/users/partials/_form_users.blade.php
@@ -4,7 +4,7 @@
 
 <div class="form-item -padded">
     <label class="field-label" for="key">User identification key:</label>
-    <input type="text" name="key" id="key" class="text-field" placeholder="Email, Mobile Phone Number, Northstar ID or Phoenix ID"/>
+    <input type="text" name="key" id="key" class="text-field" placeholder="Email, Mobile Phone Number, Northstar ID or Phoenix ID" value="{{ old('id') }}"/>
 </div>
 
 <div class="form-item -padded">
@@ -22,19 +22,19 @@
 <div class="form-item -padded">
     <p class="field-label">Specify a role for this user:</p>
     <label class="option -radio">
-      <input checked type="radio" name="role" id="member" value="member">
-      <span class="option__indicator"></span>
-      <span>Member</span>
+        <input checked type="radio" name="role" id="member" value="member">
+        <span class="option__indicator"></span>
+        <span>Member</span>
     </label>
     <label class="option -radio">
-      <input type="radio" name="role" id="staff" value="staff">
-      <span class="option__indicator"></span>
-      <span>Staff</span>
+        <input type="radio" name="role" id="staff" value="staff">
+        <span class="option__indicator"></span>
+        <span>Staff</span>
     </label>
     <label class="option -radio">
-      <input type="radio" name="role" id="admin" value="admin">
-      <span class="option__indicator"></span>
-      <span>Admin</span>
+        <input type="radio" name="role" id="admin" value="admin">
+        <span class="option__indicator"></span>
+        <span>Admin</span>
     </label>
 </div>
 

--- a/resources/views/users/partials/_form_users.blade.php
+++ b/resources/views/users/partials/_form_users.blade.php
@@ -1,0 +1,20 @@
+@include('layouts.errors')
+
+<div class="form-item -padded">
+    <label class="field-label" for="key">User identification key:</label>
+    <input type="text" name="key" id="key" class="text-field" placeholder="Email, Mobile Phone Number, Northstar ID or Phoenix ID"/>
+</div>
+
+<div class="form-item -padded">
+    <label class="field-label" for="type">Select user key type:</label>
+    <div class="select">
+        <select name="type">
+            <option value="email" selected>Email</option>
+            <option value="mobile">Mobile Phone Number</option>
+            <option value="id">Northstar ID</option>
+            <option value="drupal_id">Phoenix ID</option>
+        </select>
+    </div>
+</div>
+
+<input type="submit" class="button" value="Submit" />

--- a/resources/views/users/partials/_form_users.blade.php
+++ b/resources/views/users/partials/_form_users.blade.php
@@ -1,5 +1,7 @@
 @include('layouts.errors')
 
+{{ csrf_field() }}
+
 <div class="form-item -padded">
     <label class="field-label" for="key">User identification key:</label>
     <input type="text" name="key" id="key" class="text-field" placeholder="Email, Mobile Phone Number, Northstar ID or Phoenix ID"/>
@@ -15,6 +17,25 @@
             <option value="drupal_id">Phoenix ID</option>
         </select>
     </div>
+</div>
+
+<div class="form-item -padded">
+    <p class="field-label">Specify a role for this user:</p>
+    <label class="option -radio">
+      <input checked type="radio" name="role" id="member" value="member">
+      <span class="option__indicator"></span>
+      <span>Member</span>
+    </label>
+    <label class="option -radio">
+      <input type="radio" name="role" id="staff" value="staff">
+      <span class="option__indicator"></span>
+      <span>Staff</span>
+    </label>
+    <label class="option -radio">
+      <input type="radio" name="role" id="admin" value="admin">
+      <span class="option__indicator"></span>
+      <span>Admin</span>
+    </label>
 </div>
 
 <input type="submit" class="button" value="Submit" />

--- a/resources/views/users/partials/_table_users.blade.php
+++ b/resources/views/users/partials/_table_users.blade.php
@@ -1,0 +1,26 @@
+<div class="container">
+        <div class="wrapper">
+            <div class="container__block">
+                <h2 class="heading -banner">{{ $role }}</h2>
+
+                <table class="table">
+                    <thead>
+                        <tr class="table__header">
+                            <th class="table__cell">User</th>
+                            <th class="table__cell">First Name</th>
+                            <th class="table__cell">Last Name</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($users as $user)
+                            <tr class="table__row">
+                                <td class="table__cell"><a href="{{ route('users.show', $user->id) }}">{{ $user->id }}</a></td>
+                                <td class="table__cell">&hellip;</td>
+                                <td class="table__cell">&hellip;</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,0 +1,28 @@
+@extends('layouts.master')
+
+@section('main_content')
+
+    @include('layouts.header',[
+        'title' => 'Users'
+    ])
+
+    <div class="container">
+        <div class="wrapper">
+            <div class="container__block">
+                <h1 class="heading">First Last</h1>
+                <p><em>Need to grab user first and last name from cache once we cache their Northstar data</em></p>
+
+                <div class="key-value">
+                    <dt>ID:</dt>
+                    <dd>{{ $user->id }}</dd>
+                    <dt>Role:</dt>
+                    <dd>{{ $user->role or 'member' }}</dd>
+                </div>
+
+                <a href="{{ route('users.edit', $user->id) }}" class="button">Edit</a>
+            </div>
+        </div>
+    </div>
+
+
+@stop


### PR DESCRIPTION
# Work In Progress

#### What's this PR do?
This PR adds User CRUD interface and setups up start for user persistence in the database via POST request.

User Index
![image](https://cloud.githubusercontent.com/assets/105849/13497922/b137c252-e125-11e5-9f69-bce1d6ad3280.png)

User Create
![image](https://cloud.githubusercontent.com/assets/105849/13497986/048ddfb8-e126-11e5-9411-27f89871ccab.png)

User Show
![image](https://cloud.githubusercontent.com/assets/105849/13497938/c531a1ce-e125-11e5-9452-1c21672871a4.png)

User Edit
![image](https://cloud.githubusercontent.com/assets/105849/13497967/e50608b4-e125-11e5-962f-4f1e0acf1b06.png)


#### How should this be manually tested?
Pull down the code, run `composer dump-autoload` and log in. Try viewing the users list, editing their role or creating new ones.

#### Any background context you want to provide?
Based on an IRL conversation with @DFurnes I moved the API request storing out of the `UsersController` to place in more dedicated API related controllers since I expected to run into some trouble with middleware and how web middleware is applied to the `UsersController` and how that would affect API requests. So the API user storing is coming in a separate PR.

#### What are the relevant tickets?
Fixes #32 
Refs #22 

---
@angaither @sbsmith86 @deadlybutter 

cc: @DFurnes 