### PR TITLE
Update to fix named route path that was updated to wrong method.

### DIFF
--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -10,7 +10,7 @@
     <div class="container">
         <div class="wrapper">
             <div class="container__block">
-                <form method="POST" action="{{ route('users.create') }}">
+                <form method="POST" action="{{ route('users.store') }}">
                     @include('users.partials._form_users')
                 </form>
             </div>


### PR DESCRIPTION
#### What's this PR do?
This PR fixes a bug routing to the wrong named route on POST for creating a new user and Laravel was throwing a `MethodNotAllowedHttpException` because it should be sending the POST request to the `store()` method.

#### How should this be manually tested?
Tyr creating a new user!

#### Any background context you want to provide?
Updated to use named routes and used the wrong one :confounded: 


---
@angaither @sbsmith86 @deadlybutter 
