### PR TITLE
Use many to many eloquent relationship to save competitions

### DIFF
--- a/database/seeds/CompetitionTableSeeder.php
+++ b/database/seeds/CompetitionTableSeeder.php
@@ -27,7 +27,7 @@ class CompetitionTableSeeder extends Seeder
             $competition->competition_start_date = Carbon::now()->addWeeks(1)->startOfDay();
             $competition->competition_end_date = Carbon::now()->addWeeks(3)->endOfDay();
 
-            $contest->competition()->save($competition);
+            $contest->competitions()->save($competition);
         }
     }
 }


### PR DESCRIPTION
#### What's this PR do?

I update the Contest relationship to competitions to be `hasMany()` in the model and so I updated the method to be plural. However, I forgot to use the plural version of the function when I was calling it in the competition seeder. 

#### How should this be manually tested?

Tested on my local and we should be good. you can use the same steps as in #56 



#### What are the relevant tickets?
Ref #45  
