### PR TITLE
Updates to terminology to match Northstar.

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -4,7 +4,6 @@ namespace Gladiator\Http\Controllers\Api;
 
 use Gladiator\Models\User;
 use Gladiator\Models\Contest;
-use Gladiator\Models\WaitingRoom;
 use Gladiator\Services\Registrar;
 use Gladiator\Http\Requests\UserRequest;
 use Gladiator\Http\Transformers\UserTransformer;

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -22,8 +22,8 @@ class UserRequest extends Request
     public function rules()
     {
         $rules = [
-            'key' => 'required',
-            'type' => 'required',
+            'id' => 'required',
+            'term' => 'required',
         ];
 
         if ($this->wantsJson()) {

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -23,6 +23,8 @@ class UserTransformer extends TransformerAbstract
             'mobile' => null,
             'signup' => null,
             'reportback' => null,
+            'created_at' => $user->created_at->toIso8601String(),
+            'updated_at' => $user->updated_at->toIso8601String(),
         ];
     }
 }

--- a/app/Services/Northstar/Northstar.php
+++ b/app/Services/Northstar/Northstar.php
@@ -20,6 +20,12 @@ class Northstar extends RestApiClient
         parent::__construct($base_uri, $headers);
     }
 
+    /**
+     * Get users from Northstar for seeding database.
+     *
+     * @param  string $limit
+     * @return object|null
+     */
     public function getSeedUsers($limit = '300')
     {
         $response = $this->get('users', ['limit' => $limit]);

--- a/app/Services/Registrar.php
+++ b/app/Services/Registrar.php
@@ -62,7 +62,7 @@ class Registrar
      */
     public function findUserAccount($credentials)
     {
-        $northstarUser = $this->findNorthstarAccount($credentials['type'], $credentials['key']);
+        $northstarUser = $this->findNorthstarAccount($credentials['term'], $credentials['id']);
 
         if (! $northstarUser) {
             throw new NorthstarUserNotFoundException;

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -22,11 +22,11 @@ Content-Type: application/json
 
 ```javascript
 {
-  // Required.
-  key: String
+  // Required. An id for a user, either an email address, drupal_id, mobile phone number or Northstar id.
+  id: String
 
-  // Required. Allowed values: email, drupal_id, mobile, id (Northstar ID)
-  type: String
+  // Required. Allowed values: "email", "drupal_id", "mobile", "id" (Northstar ID)
+  term: String
 
   // Required.
   campaign_id: Number
@@ -42,12 +42,28 @@ Content-Type: application/json
 curl -X POST \
   -H "Content-Type: application/json" \
   -H "Accept: application/json" \
-  -d '{"key":"clee@dosomething.org","type":"email","campaign_id":"362","campaign_run_id":"212"}' \
+  -d '{"key":"kallark@dosomething.org","type":"email","campaign_id":"362","campaign_run_id":"212"}' \
   http://gladiator.dosomething.org/api/v1/users
 ```
 
 **Example Response**
 
-_TBD_
+```javascript
+// 200 Okay
+
+{
+  "data": {
+    "id": "550200bba39awieg467a3cg2",
+    "first_name": null,
+    "last_name": null,
+    "email": null,
+    "mobile": null,
+    "signup": null,
+    "reportback": null,
+    "created_at": "2016-03-08T18:27:10+0000",
+    "updated_at": "2016-03-08T18:27:10+0000"
+  }
+}
+```
 
 

--- a/resources/views/users/partials/_form_users.blade.php
+++ b/resources/views/users/partials/_form_users.blade.php
@@ -3,14 +3,14 @@
 {{ csrf_field() }}
 
 <div class="form-item -padded">
-    <label class="field-label" for="key">User identification key:</label>
-    <input type="text" name="key" id="key" class="text-field" placeholder="Email, Mobile Phone Number, Northstar ID or Phoenix ID" value="{{ $user->id or old('key') }}"/>
+    <label class="field-label" for="id">User identification:</label>
+    <input type="text" name="id" id="id" class="text-field" placeholder="Email, Mobile Phone Number, Northstar ID or Phoenix ID" value="{{ $user->id or old('id') }}"/>
 </div>
 
 <div class="form-item -padded">
-    <label class="field-label" for="type">Select user key type:</label>
+    <label class="field-label" for="term">Select user ID type:</label>
     <div class="select">
-        <select name="type">
+        <select name="term" id="term">
             <option value="email" {{! isset($user->id) ? 'selected' : '' }}>Email</option>
             <option value="mobile">Mobile Phone Number</option>
             <option value="id" {{ isset($user->id) ? 'selected' : '' }}>Northstar ID</option>


### PR DESCRIPTION
#### What's this PR do?
This PR updates the terminology used for both the API endpoint for `/api/v1/users` and the User CRUD form. Both had to be updated since they both use the same form request for validation and thus the fileds need to be named the same.

Also updates the API documentation to reference the changes and update with an example response.

#### How should this be manually tested?
If User crud and POST request to `/api/v1/users` doesn't break, then all is good.

#### What are the relevant tickets?
Fixes #54 

---
@angaither @sbsmith86 @deadlybutter 