### PR TITLE
Updates split functionality based on contests

### DIFF
--- a/app/Http/Controllers/WaitingRoomsController.php
+++ b/app/Http/Controllers/WaitingRoomsController.php
@@ -101,10 +101,11 @@ class WaitingRoomsController extends Controller
      * @param  \Gladiator\Models\WaitingRoom  $room
      * @return \Illuminate\Http\Response
      */
-    public function split(CompetitionRequest $request, WaitingRoom $room)
+    public function split(WaitingRoom $room)
     {
         $split = $room->getDefaultSplit();
-        $room->saveSplit($request->all(), $split);
+        $contest = Contest::find($room->contest_id);
+        $room->saveSplit($contest, $split);
 
         return redirect()->route('waitingrooms.index')->with('status', 'Waiting Room has been split!');
     }

--- a/app/Http/Controllers/WaitingRoomsController.php
+++ b/app/Http/Controllers/WaitingRoomsController.php
@@ -4,7 +4,6 @@ namespace Gladiator\Http\Controllers;
 
 use Gladiator\Models\Contest;
 use Gladiator\Models\WaitingRoom;
-use Gladiator\Http\Requests\CompetitionRequest;
 use Gladiator\Http\Requests\WaitingRoomRequest;
 
 class WaitingRoomsController extends Controller

--- a/app/Models/WaitingRoom.php
+++ b/app/Models/WaitingRoom.php
@@ -2,6 +2,7 @@
 
 namespace Gladiator\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 
 class WaitingRoom extends Model
@@ -34,6 +35,7 @@ class WaitingRoom extends Model
      */
     public function getDefaultSplit()
     {
+
         $users = $this->users;
 
         // Get the size of the waiting room
@@ -66,11 +68,20 @@ class WaitingRoom extends Model
     /*
      * Creates competitions based on the given user split.
      */
-    public function saveSplit($competitionInput, $split)
+    public function saveSplit($contest, $split)
     {
+        $startDate = Carbon::now()->startOfDay();
+        $endDate = Carbon::now()->addDays($contest->duration);
+
         foreach ($split as $competitionGroup) {
             // For each split, create a competition.
-            $competition = Competition::create($competitionInput);
+            $competition = new Competition;
+
+            $competition->contest_id = $contest->getKey();
+            $competition->competition_start_date = $startDate;
+            $competition->competition_end_date = $endDate;
+
+            $contest->competitions()->save($competition);
 
             // For each user in this group
             foreach ($competitionGroup as $userId) {

--- a/app/Models/WaitingRoom.php
+++ b/app/Models/WaitingRoom.php
@@ -35,7 +35,6 @@ class WaitingRoom extends Model
      */
     public function getDefaultSplit()
     {
-
         $users = $this->users;
 
         // Get the size of the waiting room

--- a/app/Models/WaitingRoom.php
+++ b/app/Models/WaitingRoom.php
@@ -70,7 +70,7 @@ class WaitingRoom extends Model
     public function saveSplit($contest, $split)
     {
         $startDate = Carbon::now()->startOfDay();
-        $endDate = Carbon::now()->addDays($contest->duration);
+        $endDate = Carbon::now()->addDays($contest->duration)->endOfDay();
 
         foreach ($split as $competitionGroup) {
             // For each split, create a competition.

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -50,10 +50,21 @@ class UserTableSeeder extends Seeder
         // Add Contestant Users
         $waitingRooms = WaitingRoom::all();
         $totalRooms = count($waitingRooms);
-        $seedContestants = $this->northstar->getSeedUsers(300);
+        // $seedContestants = $this->northstar->getSeedUsers(300);
+
+        // for ($i = 0; $i < 5000; $i++) {
+        //     array_push($seedContestants
+        // }
+
+        $seedContestants = [];
+
+        for ($i = 1; $i < 10; $i++) {
+            $seedContestants = array_merge($seedContestants, $this->northstar->get('users', ['limit' => 100, 'page' => $i]));
+        }
 
         foreach ($seedContestants as $contestant) {
             $index = mt_rand(0, ($totalRooms - 1));
+            $index = 0;
 
             // Using first or create if someone is already an admin.
             $user = User::firstOrCreate([

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -50,21 +50,10 @@ class UserTableSeeder extends Seeder
         // Add Contestant Users
         $waitingRooms = WaitingRoom::all();
         $totalRooms = count($waitingRooms);
-        // $seedContestants = $this->northstar->getSeedUsers(300);
-
-        // for ($i = 0; $i < 5000; $i++) {
-        //     array_push($seedContestants
-        // }
-
-        $seedContestants = [];
-
-        for ($i = 1; $i < 10; $i++) {
-            $seedContestants = array_merge($seedContestants, $this->northstar->get('users', ['limit' => 100, 'page' => $i]));
-        }
+        $seedContestants = $this->northstar->getSeedUsers(300);
 
         foreach ($seedContestants as $contestant) {
             $index = mt_rand(0, ($totalRooms - 1));
-            $index = 0;
 
             // Using first or create if someone is already an admin.
             $user = User::firstOrCreate([

--- a/resources/views/waitingrooms/split.blade.php
+++ b/resources/views/waitingrooms/split.blade.php
@@ -8,6 +8,14 @@
 
     <div class="container">
         <div class="wrapper">
+            <div class="container__block -narrow">
+                <form method="POST" action="{{ route('split', $room->id) }}">
+                    {{ method_field('POST') }}
+                    {{ csrf_field() }}
+
+                    <input type="submit" class="button" value="Split" />
+                </form>
+            </div>
             <div class="container__block container__competitions">
                 <h1>Competitions</h1>
                 @foreach($split as $competition)
@@ -20,14 +28,6 @@
                         </ul>
                     </div>
                 @endforeach
-            </div>
-            <div class="container__block -narrow">
-                <h1>Competition details</h1>
-                {!! Form::open(['method' => 'POST','route' => ['split', $room->id]]) !!}
-
-                    @include('competitions.partials._form_competitions')
-
-                {!! Form::close() !!}
             </div>
         </div>
     </div>


### PR DESCRIPTION
#### What's this PR do?
Updates the split functionality to use the new contest-y way of doing things
Removes the competition form on the split page (don't need it anymore!)
Instead it just uses the contest ID and does some simple duration adding / carbon calculations

#### How should this be manually tested?
So I updated the UserTableSeeder with this 

```
        $seedContestants = [];

        for ($i = 1; $i < 10; $i++) {
            $seedContestants = array_merge($seedContestants, $this->northstar->get('users', ['limit' => 100, 'page' => $i]));
        }
```

which got 900 users 

I also changed this bit in the contestant loop

```
            $index = mt_rand(0, ($totalRooms - 1));
            $index = 0;
```

so I could test it split 900 people in a waiting room correctly.

This is a screenshot of the /split page

![screen shot 2016-03-10 at 2 16 55 pm](https://cloud.githubusercontent.com/assets/897368/13681499/7293fe70-e6cb-11e5-9a47-f7716c01906e.png)

Then this is after the DB split.

![screen shot 2016-03-10 at 2 17 38 pm](https://cloud.githubusercontent.com/assets/897368/13681551/b61989f8-e6cb-11e5-9633-7bf8d005e8c9.png)

Also the competitions index

![screen shot 2016-03-10 at 2 24 26 pm](https://cloud.githubusercontent.com/assets/897368/13681607/f4bcea56-e6cb-11e5-93f1-c313eaaddd86.png)


#### Any background context you want to provide?
![](https://media1.giphy.com/media/uKT0MWezNGewE/200.gif)

#### What are the relevant tickets?
Fixes #62 