### PR TITLE
Fixes case in class reference

### DIFF
--- a/app/Models/Contest.php
+++ b/app/Models/Contest.php
@@ -26,7 +26,7 @@ class Contest extends Model
      */
     public function competitions()
     {
-        return $this->hasMany(competition::class);
+        return $this->hasMany(Competition::class);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
Converted a class reference to upper case (`competition` to `Competition`).

#### How should this be manually tested?
This may address https://github.com/DoSomething/phoenix/issues/6170#issuecomment-196513424

#### Any background context you want to provide?
Strange 500 errors when POSTing to the `/api/v1/users` method. The specific error is 

```
FatalErrorException in [compiled.php line 10379]():Class 'Gladiator\Models\competition' not found
```

#### What are the relevant tickets?
Fixes DoSomething/phoenix/issues/6170