### PR TITLE
Fix a bug keeping user from signing up for multiple competitions.

### DIFF
--- a/app/Services/Registrar.php
+++ b/app/Services/Registrar.php
@@ -62,7 +62,7 @@ class Registrar
      * Resolve user account within Northstar/Gladiator system.
      *
      * @param  array  $credentials
-     * @return \Gladiator\Models\User|string
+     * @return \Gladiator\Models\User|object
      * @throws \Gladiator\Services\Northstar\Exceptions\NorthstarUserNotFoundException
      */
     public function findUserAccount($credentials)
@@ -82,6 +82,6 @@ class Registrar
             return $northstarUser;
         }
 
-        return $this->repository->find($user->id);
+        return $user;
     }
 }


### PR DESCRIPTION
#### What's this PR do?
This PR updates a bug that was keeping API POSTed users from signing up for multiple competitions.

#### How should this be manually tested?
Try posting the same user to various competitions on different contests via the API. Get crazy error? No? Then it works!

#### Any background context you want to provide?
The `Registrar` class method was returning an basic object with the user info from Northstar, instead of an instance of the `User` model if they are already in the system. In the methods that call this `Registrar` method, we do a check to see if the returned info is an `instanceof User` and if it is, then doesn't try to add them again to the system but continues on its way. But by returning a standard object, the check was failing and thus assuming the user didn't already exists in Gladiator and trying to add them again :scream: 

#### What are the relevant tickets?
Fixes #88


---
@angaither @sbsmith86 @deadlybutter 