### PR TITLE
Adds getAll() method to UserRepositoryContract and implementors

### DIFF
--- a/app/Repositories/CacheUserRepository.php
+++ b/app/Repositories/CacheUserRepository.php
@@ -250,8 +250,6 @@ class CacheUserRepository implements UserRepositoryContract
         if (count($retrieved)) {
             return $data;
         }
-
-        return;
     }
 
     /**

--- a/app/Repositories/CacheUserRepository.php
+++ b/app/Repositories/CacheUserRepository.php
@@ -233,7 +233,7 @@ class CacheUserRepository implements UserRepositoryContract
      * Items not found in the cache will have a null value.
      *
      * @param  array  $keys
-     * @return array
+     * @return array|null
      */
     protected function retrieveMany(array $keys)
     {
@@ -248,7 +248,7 @@ class CacheUserRepository implements UserRepositoryContract
         }
 
         if (count($retrieved)) {
-            return Cache::many($keys);
+            return $data;
         }
 
         return;

--- a/app/Repositories/DatabaseUserRepository.php
+++ b/app/Repositories/DatabaseUserRepository.php
@@ -60,6 +60,25 @@ class DatabaseUserRepository implements UserRepositoryContract
     }
 
     /**
+     * Get collection of all users or set of users by ids.
+     *
+     * @param  array $ids Northstar IDs
+     * @return \Illuminate\Support\Collection
+     */
+    public function getAll(array $ids = [])
+    {
+        if ($ids) {
+            $accounts = $this->getBatchedCollection($ids);
+
+            return collect($accounts);
+        }
+
+        $accounts = $this->getBatchedCollection(User::all()->pluck('id')->all());
+
+        return collect($accounts);
+    }
+
+    /**
      * Get collection of users by the specified role.
      *
      * @param  string $role

--- a/app/Repositories/UserRepositoryContract.php
+++ b/app/Repositories/UserRepositoryContract.php
@@ -21,6 +21,14 @@ interface UserRepositoryContract
     public function find($id);
 
     /**
+     * Get collection of all users or set of users by ids.
+     *
+     * @param  array $ids Northstar IDs
+     * @return \Illuminate\Support\Collection
+     */
+    public function getAll(array $ids = []);
+
+    /**
      * Get collection of users by the specified role.
      *
      * @param  string $role


### PR DESCRIPTION
#### What's this PR do?
This PR exposes a `getAll()` on the `UserRepositoryContract` which allows you to call the method from the class that implements the interface, and either pass an array of ids or nothing and it will return a collection of users.

#### How should this be manually tested?
For a quick and dirty run, hijack the UserController `index()` action and try hitting `$this->repository->getAll();` and seeing what it returns. Should be a rather large collection of users! And then try it the same thing but pass an array of Northstar IDs.

#### Any background context you want to provide?
Rush job! Need to unblock @sbsmith86 and @deadlybutter so the code isn't super pretty, but gets the job done. I need to go back in and refactor a bit, because while working on this issue, it exposed a flaw in my `resolveMissingUsers()` method that checks a cached collection to make sure all the users requested were found in the cache, otherwise it goes and finds them using a single user `find()` method. You can imagine that on a large collection with lots of users missing from the cache (which can happen and is totally fine, don't sweat it :sweat_smile:) doing single requests for each of those User's for their Northstar profile info is inefficient. Best to switch it up to do a batched request! So that'll be an upgrade :dancer: 

#### What are the relevant tickets?
Fixes #89

---
@angaither @sbsmith86 @deadlybutter @DFurnes 