### PR TITLE
Contest index update

### DIFF
--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -16,6 +16,11 @@ class ContestsController extends Controller
     {
         $contests = Contest::all();
 
+        foreach ($contests as $contest) {
+            $contest->signup_end_date = $contest->waitingRoom->signup_end_date;
+            $contest->signups_open = $contest->waitingRoom->isOpen();
+        }
+
         return view('contests.index', compact('contests'));
     }
 

--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -18,7 +18,7 @@ class ContestsController extends Controller
 
         foreach ($contests as $contest) {
             $contest->signup_end_date = $contest->waitingRoom->signup_end_date;
-            $contest->signups_open = $contest->waitingRoom->isOpen();
+            $contest->signups_open = ($contest->waitingRoom->isOpen()) ? 'Open' : 'Closed';
         }
 
         return view('contests.index', compact('contests'));

--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -16,11 +16,6 @@ class ContestsController extends Controller
     {
         $contests = Contest::all();
 
-        foreach ($contests as $contest) {
-            $contest->signup_end_date = $contest->waitingRoom->signup_end_date;
-            $contest->signups_open = ($contest->waitingRoom->isOpen()) ? 'Open' : 'Closed';
-        }
-
         return view('contests.index', compact('contests'));
     }
 

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -8,6 +8,7 @@ $forge-path: "/assets/vendor/forge/assets/";
 @import "patterns/errors";
 @import "patterns/tables";
 @import "patterns/key-value";
+@import "patterns/status";
 
 .container__split {
   display: inline-block;

--- a/resources/assets/sass/patterns/_status.scss
+++ b/resources/assets/sass/patterns/_status.scss
@@ -1,0 +1,11 @@
+.status {
+  font-weight: $weight-bold;
+
+  &.-open {
+    color: #5cbe7f;
+  }
+
+  &.-closed {
+    color: $error-color;
+  }
+}

--- a/resources/views/contests/index.blade.php
+++ b/resources/views/contests/index.blade.php
@@ -25,7 +25,8 @@
                           <th class="table__cell">Campaign</th>
                           <th class="table__cell">Campaign Run</th>
                           <th class="table__cell">Duration</th>
-                          <th class="table__cell">Contestants in Waiting Room</th>
+                          <th class="table__cell">Signup End Date</th>
+                          <th class="table__cell">Signups</th>
                         </tr>
                       </thead>
                       <tbody>
@@ -35,6 +36,7 @@
                             <td class="table__cell">{{ $contest->campaign_id }}</td>
                             <td class="table__cell">{{ $contest->campaign_run_id }}</td>
                             <td class="table__cell">{{ $contest->duration }}</td>
+                            <td>{{ $contest->waitingroom->signup_end_date->format('F d, Y') }}</td>
                             <td class="table__cell"><a href="{{ route('waitingrooms.show', $contest->waitingroom->id) }}">{{ $contest->waitingroom->users->count() }}</td>
                           </tr>
                         @endforeach

--- a/resources/views/contests/index.blade.php
+++ b/resources/views/contests/index.blade.php
@@ -37,11 +37,11 @@
                                     <td class="table__cell">{{ $contest->campaign_id }}</td>
                                     <td class="table__cell">{{ $contest->campaign_run_id }}</td>
                                     <td class="table__cell">{{ $contest->duration }}</td>
-                                    <td class="table__cell">{{ $contest->waitingroom->signup_end_date->format('F d, Y') }}</td>
+                                    <td class="table__cell">{{ $contest->waitingRoom->signup_end_date->format('F d, Y') }}</td>
                                     <td class="table__cell"><a href="{{ route('waitingrooms.show', $contest->waitingroom->id) }}">{{ $contest->waitingroom->users->count() }}</td>
                                     <td class="table__cell">
-                                        <span class="status {{ "-" . strtolower($contest->signups_open) }}">
-                                            {{ $contest->signups_open }}
+                                        <span class="status {{ ($contest->waitingRoom->isOpen()) ? '-open' : '-closed' }}">
+                                            {{ ($contest->waitingRoom->isOpen()) ? 'Open' : 'Closed' }}
                                         </span>
                                     </td>
                                 </tr>

--- a/resources/views/contests/index.blade.php
+++ b/resources/views/contests/index.blade.php
@@ -19,32 +19,37 @@
             <div class="container__block">
                 <div class="table-responsive">
                     <table class="table">
-                      <thead>
-                        <tr class="table__header">
-                          <th class="table__cell">ID</th>
-                          <th class="table__cell">Campaign</th>
-                          <th class="table__cell">Campaign Run</th>
-                          <th class="table__cell">Duration</th>
-                          <th class="table__cell">Signup End Date</th>
-                          <th class="table__cell">Signups</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        @foreach($contests as $contest)
-                          <tr class="table__row">
-                            <td class="table__cell"><a href="{{ route('contests.show', $contest->id) }}">{{ $contest->id }}</a></td>
-                            <td class="table__cell">{{ $contest->campaign_id }}</td>
-                            <td class="table__cell">{{ $contest->campaign_run_id }}</td>
-                            <td class="table__cell">{{ $contest->duration }}</td>
-                            <td class="table__cell">{{ $contest->waitingroom->signup_end_date->format('F d, Y') }}</td>
-                            <td class="table__cell"><a href="{{ route('waitingrooms.show', $contest->waitingroom->id) }}">{{ $contest->waitingroom->users->count() }}</td>
-                          </tr>
-                        @endforeach
-                      </tbody>
+                        <thead>
+                            <tr class="table__header">
+                                <th class="table__cell">ID</th>
+                                <th class="table__cell">Campaign</th>
+                                <th class="table__cell">Campaign Run</th>
+                                <th class="table__cell">Duration</th>
+                                <th class="table__cell">Signup End Date</th>
+                                <th class="table__cell">Signups</th>
+                                <th class="table__cell">Waiting Room Status</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($contests as $contest)
+                                <tr class="table__row">
+                                    <td class="table__cell"><a href="{{ route('contests.show', $contest->id) }}">{{ $contest->id }}</a></td>
+                                    <td class="table__cell">{{ $contest->campaign_id }}</td>
+                                    <td class="table__cell">{{ $contest->campaign_run_id }}</td>
+                                    <td class="table__cell">{{ $contest->duration }}</td>
+                                    <td class="table__cell">{{ $contest->waitingroom->signup_end_date->format('F d, Y') }}</td>
+                                    <td class="table__cell"><a href="{{ route('waitingrooms.show', $contest->waitingroom->id) }}">{{ $contest->waitingroom->users->count() }}</td>
+                                    <td class="table__cell">
+                                        <span class="status {{ "-" . strtolower($contest->signups_open) }}">
+                                            {{ $contest->signups_open }}
+                                        </span>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
                     </table>
                 </div>
             </div>
         </div>
     </div>
-
 @stop

--- a/resources/views/contests/index.blade.php
+++ b/resources/views/contests/index.blade.php
@@ -36,7 +36,7 @@
                             <td class="table__cell">{{ $contest->campaign_id }}</td>
                             <td class="table__cell">{{ $contest->campaign_run_id }}</td>
                             <td class="table__cell">{{ $contest->duration }}</td>
-                            <td>{{ $contest->waitingroom->signup_end_date->format('F d, Y') }}</td>
+                            <td class="table__cell">{{ $contest->waitingroom->signup_end_date->format('F d, Y') }}</td>
                             <td class="table__cell"><a href="{{ route('waitingrooms.show', $contest->waitingroom->id) }}">{{ $contest->waitingroom->users->count() }}</td>
                           </tr>
                         @endforeach

--- a/resources/views/contests/partials/_form_contest.blade.php
+++ b/resources/views/contests/partials/_form_contest.blade.php
@@ -4,12 +4,12 @@
 
 <div class="form-item -padded">
     <label class="field-label" for="signup_start_date">Signup Start Date:</label>
-    <input type="date" name="signup_start_date" id="signup_start_date" class="text-field"></input>
+    <input type="date" name="signup_start_date" id="signup_start_date" value={{ $contest->waitingRoom->signup_start_date or old($contest->waitingRoom->signup_start_date)}} class="text-field"></input>
 </div>
 
 <div class="form-item -padded">
     <label class="field-label" for="signup_end_date">Signup End Date:</label>
-    <input type="date" name="signup_end_date" id="signup_end_date" class="text-field"></input>
+    <input type="date" name="signup_end_date" id="signup_end_date" value={{ $contest->waitingRoom->signup_end_date or old($contest->waitingRoom->signup_end_date)}} class="text-field"></input>
 </div>
 
 <div class="form-item -padded">


### PR DESCRIPTION
#### What's this PR do?

Adds waiting room end date to contest index

And adds a status column that shows if the waiting room is open or not. 

![screen shot 2016-03-16 at 4 19 31 pm](https://cloud.githubusercontent.com/assets/1700409/13827633/11410faa-eb94-11e5-9fb9-ccd32fa5e748.png)

#### Any background context you want to provide?

This is a little different then what we discussed and what is outlined in the issue, but I think this is the best way to do it. See the [issue for the discussion.](https://github.com/DoSomething/gladiator/issues/78)

#### What are the relevant tickets?
Fixes #78