### PR TITLE
Remove waiting room from menu.

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -7,13 +7,7 @@
                 <li>
                     <a href="{{ URL::to('contests') }}">
                         <strong class="navigation__title">Contests</strong>
-                        <span class="navigation__subtitle">"Death match" -Aaron</span>
-                    </a>
-                </li>
-                <li>
-                    <a href="{{ URL::to('waitingrooms') }}">
-                        <strong class="navigation__title">Waiting Rooms</strong>
-                        <span class="navigation__subtitle">Contestant Limbo</span>
+                        <span class="navigation__subtitle">Open, Close, Split</span>
                     </a>
                 </li>
                 <li>


### PR DESCRIPTION
#### What's this PR do?
Remove `waiting room` from nav at the top
It was mostly confusing.
I didn't remove the route or templates in case we want to bring them back later.

#### How should this be manually tested?
is the menu item gone? 

#### Any background context you want to provide?
I also updated the subtitle of the contest route, and made it more peaceful. We don't promote war-like terms here. 

#### What are the relevant tickets?
Fixes #79