### PR TITLE
Contest view updates

### DIFF
--- a/app/Http/Controllers/CompetitionsController.php
+++ b/app/Http/Controllers/CompetitionsController.php
@@ -37,18 +37,6 @@ class CompetitionsController extends Controller
     }
 
     /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index()
-    {
-        $competitions = Competition::all();
-
-        return view('competitions.index', compact('competitions'));
-    }
-
-    /**
      * Display the specified resource.
      *
      * @param  \Gladiator\Models\Competition  $competition

--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -3,10 +3,23 @@
 namespace Gladiator\Http\Controllers;
 
 use Gladiator\Models\Contest;
+use Gladiator\Services\Manager;
 use Gladiator\Http\Requests\ContestRequest;
 
 class ContestsController extends Controller
 {
+    /**
+     * Create new ContestsController instance.
+     */
+    public function __construct(Manager $manager)//UserRepositoryContract $repository,
+    {
+        // $this->repository = $repository;
+        $this->manager = $manager;
+
+        $this->middleware('auth');
+        $this->middleware('role:admin,staff');
+    }
+
     /**
      * Display a listing of the resource.
      *

--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -66,6 +66,8 @@ class ContestsController extends Controller
      */
     public function show(Contest $contest)
     {
+        $contest = $this->manager->collectContestInfo($contest->id);
+
         return view('contests.show', compact('contest'));
     }
 

--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -11,9 +11,8 @@ class ContestsController extends Controller
     /**
      * Create new ContestsController instance.
      */
-    public function __construct(Manager $manager)//UserRepositoryContract $repository,
+    public function __construct(Manager $manager)
     {
-        // $this->repository = $repository;
         $this->manager = $manager;
 
         $this->middleware('auth');

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -25,7 +25,7 @@ Route::group(['middleware' => ['web']], function () {
     // Competitions
     Route::get('competitions/{competitions}/export', 'CompetitionsController@export')->name('competitions.export');
     Route::model('competitions', 'Gladiator\Models\Competition');
-    Route::resource('competitions', 'CompetitionsController', ['except' => ['create']]);
+    Route::resource('competitions', 'CompetitionsController', ['except' => ['index', 'create']]);
 
     // Competitions
     Route::get('contests/{contest}/export', 'ContestsController@export')->name('contests.export');

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -2,6 +2,7 @@
 
 namespace Gladiator\Services;
 
+use Gladiator\Models\Contest;
 use Gladiator\Repositories\UserRepositoryContract;
 
 class Manager
@@ -62,4 +63,22 @@ class Manager
 
         return buildCSV($data);
     }
+
+    /**
+     * Collect Contest information with Waiting Room and Competitions.
+     *
+     * @param  string|\Gladiator\Models\Contest $contest
+     * @return \Gladiator\Models\Contest
+     */
+    public function collectContestInfo($data)
+    {
+        if ($data instanceof Contest) {
+            $contest = $data->with('waitingRoom.users', 'competitions.users')->firstOrFail();
+        } else {
+            $contest = Contest::with('waitingRoom.users', 'competitions.users')->findOrFail($data);
+        }
+
+        return $contest;
+    }
+
 }

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -80,5 +80,4 @@ class Manager
 
         return $contest;
     }
-
 }

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -17,10 +17,10 @@ $forge-path: "/assets/vendor/forge/assets/";
 
 .button {
   &.-danger {
-    background-color: #ff4747;
+    background-color: $error-color;
 
     &:hover {
-      background-color: #ff4747;
+      background-color: $error-color;
     }
   }
 }

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -15,3 +15,13 @@ $forge-path: "/assets/vendor/forge/assets/";
   padding: 16px;
 }
 
+.button {
+  &.-danger {
+    background-color: #ff4747;
+
+    &:hover {
+      background-color: #ff4747;
+    }
+  }
+}
+

--- a/resources/assets/sass/patterns/_errors.scss
+++ b/resources/assets/sass/patterns/_errors.scss
@@ -1,3 +1,3 @@
 .validation-error {
-  color: #ff4747;
+  color: $error-color;
 }

--- a/resources/views/contests/show.blade.php
+++ b/resources/views/contests/show.blade.php
@@ -45,11 +45,14 @@
         <div class="wrapper">
             <div class="container__block">
                 <h2 class="heading -alpha">Waiting Room</h2>
-                <p>The waiting room currently contains {{ '#' }} contestants.</p>
+                <p>The waiting room for this contest currently contains <strong>{{ $contest->waitingRoom->users->count() }}</strong> {{ $contest->waitingRoom->users->count() === 1 ? 'contestant' : 'contestants'  }}.</p>
+
+                <p><a href="/" class="button -secondary">View Waiting Room</a></p>
             </div>
         </div>
     </div>
 
+    @if ($contest->competitions->count())
     <div class="container">
         <div class="wrapper">
             <div class="container__block">
@@ -59,26 +62,27 @@
                     <table class="table">
                       <thead>
                         <tr class="table__header">
-                          <th class="table__cell">ID</th>
-                          <th class="table__cell">Contest ID</th>
+                          <th class="table__cell">Competition ID</th>
                           <th class="table__cell">Start Date</th>
                           <th class="table__cell">End Date</th>
                           <th class="table__cell"># of Contestants</th>
                         </tr>
                       </thead>
                       <tbody>
-                        <tr class="table__row">
-                            <td class="table__cell"></td>
-                            <td class="table__cell"></td>
-                            <td class="table__cell"></td>
-                            <td class="table__cell"></td>
-                            <td class="table__cell"></td>
-                        </tr>
+                        @foreach ($contest->competitions as $competition)
+                            <tr class="table__row">
+                                <td class="table__cell">{{ $competition->id }}</td>
+                                <td class="table__cell">{{ $competition->competition_start_date->format('F d, Y') }}</td>
+                                <td class="table__cell">{{ $competition->competition_end_date->format('F d, Y') }}</td>
+                                <td class="table__cell">{{ $competition->users->count() }}</td>
+                            </tr>
+                        @endforeach
                       </tbody>
                     </table>
                 </div>
             </div>
         </div>
     </div>
+    @endif
 
 @stop

--- a/resources/views/contests/show.blade.php
+++ b/resources/views/contests/show.blade.php
@@ -4,38 +4,79 @@
 
     @include('layouts.header', [
         'title' => 'Contests',
-        'subtitle' => 'Viewing contest ' . $contest->id
+        'subtitle' => 'Viewing contest ID: ' . $contest->id
     ])
 
     <div class="container">
         <div class="wrapper">
             <div class="container__block -half">
                 <ul>
-                    <li><strong>Contest ID:</strong> {{ $contest->campaign_id }}</li>
-                    <li><strong>Contest Run ID:</strong> {{ $contest->campaign_run_id }}</li>
+                    <li><strong>Campaign ID:</strong> {{ $contest->campaign_id }}</li>
+                    <li><strong>Campaign Run ID:</strong> {{ $contest->campaign_run_id }}</li>
                     <li><strong>Duration:</strong> {{ $contest->duration }}</li>
                 </ul>
             </div>
+
             <div class="container__block -half">
                 <ul class="form-actions -inline">
                     <li>
-                        <a href="{{ route('contests.edit', $contest->id) }}" class="button">Edit</a>
+                        <a href="{{ route('contests.edit', $contest->id) }}" class="button -secondary">Edit</a>
                     </li>
                     <li>
-                        <a href="{{ route('contests.export', $contest->id) }}" class="button">Export</a>
+                        <a href="{{ route('contests.export', $contest->id) }}" class="button -secondary">Export</a>
                     </li>
                     <li>
-                        <a href="{{ route('split', $contest->waitingRoom->id) }}" class="button">Split</a>
+                        <a href="{{ route('split', $contest->waitingRoom->id) }}" class="button -secondary">Split</a>
                     </li>
                     <li>
                         <form method="POST" action="{{ route('contests.destroy', $contest->id) }}">
                             {{ method_field('DELETE') }}
                             {{ csrf_field() }}
 
-                            <input type="submit" class="button" value="Delete" />
+                            <input type="submit" class="button -danger" value="Delete" />
                         </form>
                     </li>
                 </ul>
+            </div>
+        </div>
+    </div>
+
+    <div class="container">
+        <div class="wrapper">
+            <div class="container__block">
+                <h2 class="heading -alpha">Waiting Room</h2>
+                <p>The waiting room currently contains {{ '#' }} contestants.</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="container">
+        <div class="wrapper">
+            <div class="container__block">
+                <h2 class="heading -alpha">Competitions</h2>
+
+                <div class="table-responsive">
+                    <table class="table">
+                      <thead>
+                        <tr class="table__header">
+                          <th class="table__cell">ID</th>
+                          <th class="table__cell">Contest ID</th>
+                          <th class="table__cell">Start Date</th>
+                          <th class="table__cell">End Date</th>
+                          <th class="table__cell"># of Contestants</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr class="table__row">
+                            <td class="table__cell"></td>
+                            <td class="table__cell"></td>
+                            <td class="table__cell"></td>
+                            <td class="table__cell"></td>
+                            <td class="table__cell"></td>
+                        </tr>
+                      </tbody>
+                    </table>
+                </div>
             </div>
         </div>
     </div>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -11,21 +11,15 @@
                     </a>
                 </li>
                 <li>
-                    <a href="{{ URL::to('competitions') }}">
-                        <strong class="navigation__title">Competitions</strong>
-                        <span class="navigation__subtitle">Contestant groups</span>
-                    </a>
-                </li>
-                <li>
                     <a href="{{ URL::to('users') }}">
                         <strong class="navigation__title">Users</strong>
-                        <span class="navigation__subtitle">Admins, Staff, Members</span>
+                        <span class="navigation__subtitle">Admins, Staff, Contestants</span>
                     </a>
                 </li>
                 <li>
                     <a href="/">
                         <strong class="navigation__title">Settings</strong>
-                        <span class="navigation__subtitle">App configuration</span>
+                        <span class="navigation__subtitle">App Configuration</span>
                     </a>
                 </li>
             </ul>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -16,12 +16,6 @@
                         <span class="navigation__subtitle">Admins, Staff, Contestants</span>
                     </a>
                 </li>
-                <li>
-                    <a href="/">
-                        <strong class="navigation__title">Settings</strong>
-                        <span class="navigation__subtitle">App Configuration</span>
-                    </a>
-                </li>
             </ul>
         @endif
 


### PR DESCRIPTION
#### What's this PR do?
This PR updates the single **Contest** view page. It adds information on the associated Waiting Room for the contest as well as a list of competitions associated with the contest. It also adds a new method available on the `Manager` service called `collectContestInfo($data)` which can be passed _either_ a contest ID **or** an instance of `Contest` (fancy right?!). 

Anyhoo, it can distinguish between both and returns an instance of `Contest` in both cases along with the waiting room and competitions for the contest, annnnd the list of users in the waiting room, and each competition. _Note: It's not grabbing these from cache since it's doesn't need the user's profile info in the view._

It also removes the `/competitions` route since we no longer need it.

This PR also adds middleware to the `ContestController` which was missing and allowing anonymous users access to the `/contests/*` pages.

#### Screenshots
![image](https://cloud.githubusercontent.com/assets/105849/13862029/fe1f8bb2-ec66-11e5-9519-2608ac252558.png)

#### How should this be manually tested?
Pull down branch, then try to go view a specific Contest in the system and see if it looks sorta like the screenshot above.

#### Any background context you want to provide?
Laravel is pretty cool :wink: 

#### What are the relevant tickets?
Fixes #83
Fixes #87

---
@angaither @DFurnes @sbsmith86 @deadlybutter 