### PR TITLE
log in not login

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -22,9 +22,9 @@
         <ul class="navigation__secondary">
             <li>
                 @if (Auth::user())
-                    <a href="/auth/logout">Logout</a>
+                    <a href="/auth/logout">Log Out</a>
                 @else
-                    <a href="/auth/login">Login</a>
+                    <a href="/auth/login">Log In</a>
                 @endif
             </li>
         </ul>


### PR DESCRIPTION
#### What's this PR do?
Updated menu to say `Log In` instead of `login`

#### How should this be manually tested?
are there spaces?  :space_invader: 

#### Any background context you want to provide?
We use Log In and Log Out on other sites.
Keep it consistent.