### PR TITLE
Fixing assigned roles to cached users which were not having a role assigned.

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -46,8 +46,6 @@ class UsersController extends Controller
         $staff = $this->repository->getAllByRole('staff');
         $contestants = $this->repository->getAllByRole();
 
-        // dd($admins);
-        // dd($contestants);
         return view('users.index', compact('admins', 'staff', 'contestants'));
     }
 

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -46,6 +46,8 @@ class UsersController extends Controller
         $staff = $this->repository->getAllByRole('staff');
         $contestants = $this->repository->getAllByRole();
 
+        // dd($admins);
+        // dd($contestants);
         return view('users.index', compact('admins', 'staff', 'contestants'));
     }
 

--- a/app/Repositories/CacheUserRepository.php
+++ b/app/Repositories/CacheUserRepository.php
@@ -117,9 +117,10 @@ class CacheUserRepository implements UserRepositoryContract
         }
 
         $users = $this->repository->getAllByRole($role);
+
         if ($users->count()) {
-            $ids = $users->pluck('id')->toArray();
-            $collection = $users->keyBy('id')->toArray();
+            $ids = $users->pluck('id')->all();
+            $collection = $users->keyBy('id')->all();
 
             $this->store($key . ':ids', $ids);
             $this->storeMany($collection);

--- a/app/Repositories/CacheUserRepository.php
+++ b/app/Repositories/CacheUserRepository.php
@@ -117,10 +117,9 @@ class CacheUserRepository implements UserRepositoryContract
         }
 
         $users = $this->repository->getAllByRole($role);
-
         if ($users->count()) {
             $ids = $users->pluck('id')->toArray();
-            $collection = collect($users)->keyBy('id')->toArray();
+            $collection = $users->keyBy('id')->toArray();
 
             $this->store($key . ':ids', $ids);
             $this->storeMany($collection);


### PR DESCRIPTION
#### What's this PR do?
This PR makes an update to fix an issue with batch collection of users. When running batch collections the User's role in the database wasn't getting assigned to the User object, whereas when doing a single User find it does get appended. This corrects that.

#### How should this be manually tested?
View the "Users" index page, click on an admin user and make sure in their view they are indicated as "admin" and not "member". Same for staff users.

#### Any background context you want to provide?
Found what is a potential bug/feature in Northstar. When querying the `/users` endpoint on Northstar with a specific list of users, if any of the users aren't found, there is no indication. Talked to @DFurnes IRL and we discussed possible passing an additional parameter that could signify that we _do want to know_ what users couldn't be retrieved by returning `false` or `null` for that user in the resulting array response.

#### What are the relevant tickets?
Fixes #117

---
@angaither @sbsmith86 @deadlybutter @DFurnes 