### PR TITLE
App now responds properly with appropriate error responses.

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -46,7 +46,6 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $e)
     {
-
         if ($request->ajax() || $request->wantsJson()) {
             return $this->json($request, $e);
         }
@@ -56,7 +55,7 @@ class Handler extends ExceptionHandler
         }
 
         if ($e instanceof NorthstarUserNotFoundException) {
-            return redirect()->back()->with('status', $e->getMessage());
+            return redirect()->back()->withInput($request->input())->with('status', $e->getMessage());
         }
 
         return parent::render($request, $e);

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,0 +1,17 @@
+@extends('layouts.master')
+
+@section('main_content')
+
+    @include('layouts.header',[
+        'title' => '404'
+    ])
+
+    <div class="container">
+        <div class="wrapper">
+            <div class="container__block">
+                <p>Sorry, that resource was not found.</p>
+            </div>
+        </div>
+    </div>
+
+@stop


### PR DESCRIPTION
#### What's this PR do?
This PR updates responses so if an API related error occurs, the app now responds with an appropriate error response formatted in JSON, and if the same error occurs via the web app we can now differentiate and respond accordingly to that as well.

For the Northstar user not found error, we now have responses that deal with both avenues.

**API Error Response:**
![image](https://cloud.githubusercontent.com/assets/105849/13925305/3398a4a0-ef5e-11e5-8669-35d1b5b763f9.png)

**Web App Error Response:**
![image](https://cloud.githubusercontent.com/assets/105849/13925519/f1003ba2-ef5e-11e5-8167-bd96617ff189.png)

Also added a 404 page template which I tried at first for the web app but decided best to redirect back to the form with a status message instead, but doesn't hurt to keep it.

#### How should this be manually tested?
Try passing a an email you know won't exist on Northstar to create a new user via both the API POST request and via the add User form in the web app and see if the response matches what is indicated above.

#### Any background context you want to provide?
Proper error responses! :dancer: 

_Note:_ followed a similar approach to what's going on in Northstar :)

#### What are the relevant tickets?
Fixes #119

---
@angaither @DFurnes @sbsmith86 @deadlybutter 