### PR TITLE
default value for flagged status

### DIFF
--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -148,6 +148,9 @@ class Manager
             $signup->reportback->updated_at = new Carbon($signup->reportback->updated_at);
             $signup->reportback->updated_at = $signup->reportback->updated_at->format('Y-m-d');
 
+            // Return set flagged status to 'pending' if it is false.
+            $signup->reportback->flagged = ($signup->reportback->flagged) ? $signup->reportback->flagged : 'pending';
+
             // Return the reportback.
             return $signup->reportback;
         }


### PR DESCRIPTION
#### What's this PR do?

Sets the flagged status to `pending` when it is returned as false from the API.

<img width="907" alt="screen shot 2016-03-21 at 8 08 30 pm" src="https://cloud.githubusercontent.com/assets/1700409/13938125/10746476-efa1-11e5-808e-908207e71564.png">

#### What are the relevant tickets?
Fixes #126 
