### PR TITLE
add competitions count to contest view

### DIFF
--- a/resources/views/contests/index.blade.php
+++ b/resources/views/contests/index.blade.php
@@ -28,6 +28,7 @@
                                 <th class="table__cell">Signup End Date</th>
                                 <th class="table__cell">Signups</th>
                                 <th class="table__cell">Waiting Room Status</th>
+                                <th class="table__cell">Competitions</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -40,12 +41,13 @@
                                     <td class="table__cell">{{ $contest->campaign_run_id }}</td>
                                     <td class="table__cell">{{ $contest->duration }}</td>
                                     <td class="table__cell">{{ $contest->waitingRoom->signup_end_date->format('F d, Y') }}</td>
-                                    <td class="table__cell"><a href="{{ route('waitingrooms.show', $contest->waitingroom->id) }}">{{ $contest->waitingroom->users->count() }}</td>
+                                    <td class="table__cell"><a href="{{ route('waitingrooms.show', $contest->waitingroom->id) }}">{{ $contest->waitingroom->users->count() }}</a></td>
                                     <td class="table__cell">
                                         <span class="status {{ ($contest->waitingRoom->isOpen()) ? '-open' : '-closed' }}">
                                             {{ ($contest->waitingRoom->isOpen()) ? 'Open' : 'Closed' }}
                                         </span>
                                     </td>
+                                    <td class="table__cell">{{ $contest->competitions->count() }}</td>
                                 </tr>
                             @endforeach
                         </tbody>


### PR DESCRIPTION
#### What's this PR do?
When I was testing some stuff on another PR, I felt like it was a little hard to figure out which contests had been split into competitions already. So this PR just adds the count of competitions a contest has. 

<img width="915" alt="screen shot 2016-03-21 at 8 25 16 pm" src="https://cloud.githubusercontent.com/assets/1700409/13938315/15cade76-efa3-11e5-85be-e6f8eabc63ef.png">

#### How should this be manually tested?
go to `/contests` you should see a new "competitions" column with the count of competitions for that contest.

#### What are the relevant tickets?
Fixes #124 
