### PR TITLE
Northstar exception update

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -72,10 +72,6 @@ class Handler extends ExceptionHandler
     {
         $code = 500;
 
-        // if ($e instanceof NorthstarUserNotFoundException) {
-        //     $code = 404;
-        // }
-
         if ($this->isHttpException($e)) {
             $code = $e->getStatusCode();
         }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -72,9 +72,9 @@ class Handler extends ExceptionHandler
     {
         $code = 500;
 
-        if ($e instanceof NorthstarUserNotFoundException) {
-            $code = 404;
-        }
+        // if ($e instanceof NorthstarUserNotFoundException) {
+        //     $code = 404;
+        // }
 
         if ($this->isHttpException($e)) {
             $code = $e->getStatusCode();

--- a/app/Services/Northstar/Exceptions/NorthstarUserNotFoundException.php
+++ b/app/Services/Northstar/Exceptions/NorthstarUserNotFoundException.php
@@ -2,15 +2,15 @@
 
 namespace Gladiator\Services\Northstar\Exceptions;
 
-use Exception;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
-class NorthstarUserNotFoundException extends Exception
+class NorthstarUserNotFoundException extends HttpException
 {
     /**
      * Make a new Northstar User exception.
      */
     public function __construct()
     {
-        parent::__construct('Northstar user was not found.');
+        parent::__construct(404, 'Northstar user was not found.');
     }
 }


### PR DESCRIPTION
#### What's this PR do?
This PR removes the need to do `instanceof` checks for the API error responses. During PR #129 found it's easier to extend the `HttpException` class from Symphony and pass the error code in the custom exception class definition and then in the Handler, if the exception is of that type, we can just grab the error code with `$e->getStatusCode()` in a more generic fashion. Using a similar approach for other http exceptions will help eliminate the need for a slew of `if` conditions in the `Handler` class.

#### How should this be manually tested?
When creating a bogus user with email not on Northstar, or when using the API to create a user with email not on Northstar, do you get appropriate error responses? Great!

#### What are the relevant tickets?
None, just helpful cleanup.

---
@angaither @DFurnes @sbsmith86 @deadlybutter 