### PR TITLE
Update to not show all users in waiting room.

### DIFF
--- a/app/Http/Controllers/WaitingRoomsController.php
+++ b/app/Http/Controllers/WaitingRoomsController.php
@@ -69,9 +69,15 @@ class WaitingRoomsController extends Controller
      */
     public function show(WaitingRoom $room)
     {
+        $users = [];
+
         $contest = Contest::find($room->contest_id);
 
-        $users = $this->repository->getAll($room->users->pluck('id')->toArray());
+        $ids = $room->users->pluck('id')->toArray();
+
+        if ($ids) {
+            $users = $this->repository->getAll($ids);
+        }
 
         return view('waitingrooms.show', compact('room', 'contest', 'users'));
     }


### PR DESCRIPTION
#### What's this PR do?
This PR updates the `WaitingRoomsController` `show()` method, so that it first checks to see if the search for users in the specific waiting room returns an empty array, then don't try and go to the repository to grab the users. The default for the `getAll()` method `$ids` param is an empty array, which signals that method to go ahead and instead of grabbing a bunch of users based on specified ids, to just grab alllll the users.

The `WaitingRoomsController` was sending through an empty array which was leading to the above condition. So if there's no one in the waiting room after a split action, the users is an empty array and we should just return that to the `view()` instead of even bothering with the repository.

#### How should this be manually tested?
Load up a waiting room that's already split (and not accepting new signups)... there should be no users in there.

#### Any background context you want to provide?
I was contemplating adding a conditional that removes the **Signups** table from inside the Waiting Room show template, but decided that maybe it's best to leave it showing empty and Signups as `0` so it's more obvious that there are no signups:

![screen shot 2016-03-22 at 6 13 58 pm](https://cloud.githubusercontent.com/assets/105849/13969742/03865a02-f05b-11e5-8fac-999c886c6cfe.png)

#### What are the relevant tickets?
Fixes #131

---
@angaither @sbsmith86 @deadlybutter 