### PR TITLE
Messages schema and model.

### DIFF
--- a/app/Models/Contest.php
+++ b/app/Models/Contest.php
@@ -22,11 +22,19 @@ class Contest extends Model
     }
 
     /**
-     * Get the competition associated with this contest.
+     * Get the competitions associated with this contest.
      */
     public function competitions()
     {
         return $this->hasMany(Competition::class);
+    }
+
+    /**
+     * Get the messages associated with this contest.
+     */
+    public function messages()
+    {
+        return $this->hasMany(Message::class);
     }
 
     /**

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Gladiator\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Message extends Model
+{
+    /**
+     * Array of available message types.
+     *
+     * @var array
+     */
+    protected static $types = [
+        'reminder',
+    ];
+
+    /**
+     * Get the list of Message types.
+     *
+     * @return array
+     */
+    public static function getTypes()
+    {
+        return static::$types;
+    }
+}

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -12,8 +12,8 @@ class Message extends Model
      * @var array
      */
     protected static $types = [
-        'leaderboard_update',
         'leaderboard_final',
+        'leaderboard_update',
         'reminder',
         'reminder_first',
         'reminder_last',

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -12,8 +12,21 @@ class Message extends Model
      * @var array
      */
     protected static $types = [
+        'leaderboard_update',
+        'leaderboard_final',
         'reminder',
+        'reminder_first',
+        'reminder_last',
+        'welcome',
     ];
+
+    /**
+     * Get the contest associated with this message.
+     */
+    public function contest()
+    {
+        return $this->belongsTo(Contest::class);
+    }
 
     /**
      * Get the list of Message types.

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -12,11 +12,8 @@ class Message extends Model
      * @var array
      */
     protected static $types = [
-        'leaderboard_final',
-        'leaderboard_update',
+        'leaderboard',
         'reminder',
-        'reminder_first',
-        'reminder_last',
         'welcome',
     ];
 

--- a/database/migrations/2016_03_23_175405_create_messages_table.php
+++ b/database/migrations/2016_03_23_175405_create_messages_table.php
@@ -17,7 +17,7 @@ class CreateMessagesTable extends Migration
             $table->integer('contest_id')->unsigned()->index();
             $table->foreign('contest_id')->references('id')->on('contests')->onDelete('cascade');
             $table->string('type')->index();
-            $table->subject('subject')->nullable();
+            $table->string('subject')->nullable();
             $table->longText('body')->nullable();
             $table->timestamps();
         });

--- a/database/migrations/2016_03_23_175405_create_messages_table.php
+++ b/database/migrations/2016_03_23_175405_create_messages_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateMessagesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('messages', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('contest_id')->unsigned()->index();
+            $table->foreign('contest_id')->references('id')->on('contests')->onDelete('cascade');
+            $table->string('type')->index();
+            $table->subject('subject')->nullable();
+            $table->longText('body')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('messages');
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
This PR adds the migration for upcoming Messages work. It also adds a `Message` model and a helper function to extract the different message types when needed, and adds associated relationship method to the `Contest` model.

#### How should this be manually tested?
Just :eyes: the code. Nothing to test just yet! **Most importantly**, closely review the migration and make sure that all looks correct... should there be an `index()` on the `type`? I figured it'd be useful, but also not a MySQL :neckbeard: 

#### Any background context you want to provide?
We were initially thinking of using `enum` for the `type` column data type, but it could end up complicating things, especially when adding/removing different email types in the future and needing to do that all with costly migrations :scream_cat: 

#### What are the relevant tickets?
Fixes #130

---
@angaither @sbsmith86 @deadlybutter 