### PR TITLE
Remove duration, set end date on split

### DIFF
--- a/app/Http/Controllers/WaitingRoomsController.php
+++ b/app/Http/Controllers/WaitingRoomsController.php
@@ -127,7 +127,7 @@ class WaitingRoomsController extends Controller
         $contest = Contest::find($room->contest_id);
         $room->saveSplit($contest, $split);
 
-        return redirect()->route('waitingrooms.index')->with('status', 'Waiting Room has been split!');
+        return redirect()->route('contests.show', $room->contest_id)->with('status', 'Waiting Room has been split!');
     }
 
     /**

--- a/app/Http/Controllers/WaitingRoomsController.php
+++ b/app/Http/Controllers/WaitingRoomsController.php
@@ -111,6 +111,11 @@ class WaitingRoomsController extends Controller
     {
         $split = $room->getDefaultSplit();
 
+        // Get user info from Northstar.
+        foreach ($split as $key => $users) {
+            $split[$key] = $this->repository->getAll($users);
+        }
+
         return view('waitingrooms.split', compact('split', 'room'));
     }
 

--- a/app/Http/Controllers/WaitingRoomsController.php
+++ b/app/Http/Controllers/WaitingRoomsController.php
@@ -7,6 +7,7 @@ use Gladiator\Models\WaitingRoom;
 use Gladiator\Http\Requests\WaitingRoomRequest;
 use Gladiator\Repositories\UserRepositoryContract;
 use Gladiator\Services\Manager;
+use Gladiator\Http\Requests\SplitRequest;
 
 class WaitingRoomsController extends Controller
 {
@@ -111,11 +112,6 @@ class WaitingRoomsController extends Controller
     {
         $split = $room->getDefaultSplit();
 
-        // Get user info from Northstar.
-        foreach ($split as $key => $users) {
-            $split[$key] = $this->repository->getAll($users);
-        }
-
         return view('waitingrooms.split', compact('split', 'room'));
     }
 
@@ -126,11 +122,11 @@ class WaitingRoomsController extends Controller
      * @param  \Gladiator\Models\WaitingRoom  $room
      * @return \Illuminate\Http\Response
      */
-    public function split(WaitingRoom $room)
+    public function split(SplitRequest $request, WaitingRoom $room)
     {
         $split = $room->getDefaultSplit();
         $contest = Contest::find($room->contest_id);
-        $room->saveSplit($contest, $split);
+        $room->saveSplit($contest, $split, $request->competition_end_date);
 
         return redirect()->route('contests.show', $room->contest_id)->with('status', 'Waiting Room has been split!');
     }

--- a/app/Http/Requests/ContestRequest.php
+++ b/app/Http/Requests/ContestRequest.php
@@ -24,7 +24,6 @@ class ContestRequest extends Request
         return [
             'campaign_id' => 'required|numeric',
             'campaign_run_id' => 'required|numeric',
-            'duration' => 'required|numeric',
             'signup_start_date' => 'required|date',
             'signup_end_date' => 'required|date',
         ];

--- a/app/Http/Requests/SplitRequest.php
+++ b/app/Http/Requests/SplitRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Gladiator\Http\Requests;
+
+class SplitRequest extends Request
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'competition_end_date' => 'required|date|after:today',
+        ];
+    }
+}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -23,13 +23,13 @@ Route::group(['middleware' => ['web']], function () {
     Route::get('auth/logout', 'Auth\AuthController@logout');
 
     // Competitions
-    Route::get('competitions/{competitions}/export', 'CompetitionsController@export')->name('competitions.export');
     Route::model('competitions', 'Gladiator\Models\Competition');
+    Route::get('competitions/{competitions}/export', 'CompetitionsController@export')->name('competitions.export');
     Route::resource('competitions', 'CompetitionsController', ['except' => ['index', 'create']]);
 
     // Competitions
-    Route::get('contests/{contest}/export', 'ContestsController@export')->name('contests.export');
     Route::model('contests', 'Gladiator\Models\Contest');
+    Route::get('contests/{contest}/export', 'ContestsController@export')->name('contests.export');
     Route::resource('contests', 'ContestsController');
 
     // Users
@@ -40,10 +40,10 @@ Route::group(['middleware' => ['web']], function () {
     ]);
 
     // Waiting rooms routes.
+    Route::model('waitingrooms', 'Gladiator\Models\WaitingRoom');
     Route::get('waitingrooms/{waitingrooms}/export', 'WaitingRoomsController@export')->name('waitingrooms.export');
     Route::get('waitingrooms/{waitingrooms}/split', 'WaitingRoomsController@showSplitForm')->name('split');
     Route::post('waitingrooms/{waitingrooms}/split', 'WaitingRoomsController@split')->name('split');
-    Route::model('waitingrooms', 'Gladiator\Models\WaitingRoom');
     Route::resource('waitingrooms', 'WaitingRoomsController', ['except' => ['create', 'destroy']]);
 
 });

--- a/app/Models/Contest.php
+++ b/app/Models/Contest.php
@@ -11,7 +11,7 @@ class Contest extends Model
      *
      * @var array
      */
-    protected $fillable = ['campaign_id', 'campaign_run_id', 'duration'];
+    protected $fillable = ['campaign_id', 'campaign_run_id'];
 
     /**
      * Get the waiting room associated with this contest.

--- a/app/Models/WaitingRoom.php
+++ b/app/Models/WaitingRoom.php
@@ -89,10 +89,10 @@ class WaitingRoom extends Model
     /*
      * Creates competitions based on the given user split.
      */
-    public function saveSplit($contest, $split)
+    public function saveSplit($contest, $split, $endDate)
     {
         $startDate = Carbon::now()->startOfDay();
-        $endDate = Carbon::now()->addDays($contest->duration)->endOfDay();
+        $endDate = new Carbon($endDate);
 
         foreach ($split as $competitionGroup) {
             // For each split, create a competition.

--- a/app/Models/WaitingRoom.php
+++ b/app/Models/WaitingRoom.php
@@ -100,7 +100,7 @@ class WaitingRoom extends Model
 
             $competition->contest_id = $contest->getKey();
             $competition->competition_start_date = $startDate;
-            $competition->competition_end_date = $endDate;
+            $competition->competition_end_date = $endDate->endOfDay();
 
             $contest->competitions()->save($competition);
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "laravelcollective/html": "^5.2",
         "league/fractal": "^0.13.0",
         "predis/predis": "^1.0",
-        "league/csv": "^8.0"
+        "league/csv": "^8.0",
+        "doctrine/dbal": "^2.5"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "738811c5311274be64ef88ee14a5b157",
-    "content-hash": "ae89c2967f10286ae5701545172566e5",
+    "hash": "d8f849e6ed03c3a558011dadad29a763",
+    "content-hash": "8d44bc39cc626fe6081767463cfa573e",
     "packages": [
         {
             "name": "classpreloader/classpreloader",
@@ -95,6 +95,354 @@
             "time": "2014-10-24 07:27:01"
         },
         {
+            "name": "doctrine/annotations",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "f25c8aab83e0c3e976fd7d19875f198ccf2f7535"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/f25c8aab83e0c3e976fd7d19875f198ccf2f7535",
+                "reference": "f25c8aab83e0c3e976fd7d19875f198ccf2f7535",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "4.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Annotations\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2015-08-31 12:32:49"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/f8af318d14bdb0eff0336795b428b547bd39ccb6",
+                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~5.5|~7.0"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8|~5.0",
+                "predis/predis": "~1.0",
+                "satooshi/php-coveralls": "~0.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Caching library offering an object-oriented API for many cache backends",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "cache",
+                "caching"
+            ],
+            "time": "2015-12-31 16:37:02"
+        },
+        {
+            "name": "doctrine/collections",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "6c1e4eef75f310ea1b3e30945e9f06e652128b8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/6c1e4eef75f310ea1b3e30945e9f06e652128b8a",
+                "reference": "6c1e4eef75f310ea1b3e30945e9f06e652128b8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Collections\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Collections Abstraction library",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "array",
+                "collections",
+                "iterator"
+            ],
+            "time": "2015-04-14 22:21:58"
+        },
+        {
+            "name": "doctrine/common",
+            "version": "v2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/common.git",
+                "reference": "a579557bc689580c19fee4e27487a67fe60defc0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/a579557bc689580c19fee4e27487a67fe60defc0",
+                "reference": "a579557bc689580c19fee4e27487a67fe60defc0",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "1.*",
+                "doctrine/cache": "1.*",
+                "doctrine/collections": "1.*",
+                "doctrine/inflector": "1.*",
+                "doctrine/lexer": "1.*",
+                "php": "~5.5|~7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8|~5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common Library for Doctrine projects",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "collections",
+                "eventmanager",
+                "persistence",
+                "spl"
+            ],
+            "time": "2015-12-25 13:18:31"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "v2.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "abbdfd1cff43a7b99d027af3be709bc8fc7d4769"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/abbdfd1cff43a7b99d027af3be709bc8fc7d4769",
+                "reference": "abbdfd1cff43a7b99d027af3be709bc8fc7d4769",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": ">=2.4,<2.7-dev",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*",
+                "symfony/console": "2.*"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\DBAL\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Database Abstraction Layer",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "dbal",
+                "persistence",
+                "queryobject"
+            ],
+            "time": "2016-01-05 22:11:12"
+        },
+        {
             "name": "doctrine/inflector",
             "version": "v1.1.0",
             "source": {
@@ -162,17 +510,71 @@
             "time": "2015-11-06 14:35:42"
         },
         {
-            "name": "guzzlehttp/guzzle",
-            "version": "6.1.1",
+            "name": "doctrine/lexer",
+            "version": "v1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "c6851d6e48f63b69357cbfa55bca116448140e0c"
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/c6851d6e48f63b69357cbfa55bca116448140e0c",
-                "reference": "c6851d6e48f63b69357cbfa55bca116448140e0c",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Lexer\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "lexer",
+                "parser"
+            ],
+            "time": "2014-09-09 13:34:57"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "d094e337976dff9d8e2424e8485872194e768662"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d094e337976dff9d8e2424e8485872194e768662",
+                "reference": "d094e337976dff9d8e2424e8485872194e768662",
                 "shasum": ""
             },
             "require": {
@@ -188,7 +590,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.1-dev"
+                    "dev-master": "6.2-dev"
                 }
             },
             "autoload": {
@@ -221,7 +623,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2015-11-23 00:47:50"
+            "time": "2016-03-21 20:02:09"
         },
         {
             "name": "guzzlehttp/promises",
@@ -479,16 +881,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v5.2.22",
+            "version": "v5.2.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "aec1b7cb9ec0bac0107361a3730cac9b6f945ef4"
+                "reference": "396297a5fd3c70c2fc1af68f09ee574a2380175c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/aec1b7cb9ec0bac0107361a3730cac9b6f945ef4",
-                "reference": "aec1b7cb9ec0bac0107361a3730cac9b6f945ef4",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/396297a5fd3c70c2fc1af68f09ee574a2380175c",
+                "reference": "396297a5fd3c70c2fc1af68f09ee574a2380175c",
                 "shasum": ""
             },
             "require": {
@@ -501,7 +903,7 @@
                 "monolog/monolog": "~1.11",
                 "mtdowling/cron-expression": "~1.0",
                 "nesbot/carbon": "~1.20",
-                "paragonie/random_compat": "~1.1",
+                "paragonie/random_compat": "~1.4",
                 "php": ">=5.5.9",
                 "psy/psysh": "0.7.*",
                 "swiftmailer/swiftmailer": "~5.1",
@@ -603,7 +1005,7 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2016-02-27 22:09:19"
+            "time": "2016-03-22 13:45:19"
         },
         {
             "name": "laravelcollective/html",
@@ -718,16 +1120,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.18",
+            "version": "1.0.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "b334d6c5f95364948e06d2f620ab93d084074c6e"
+                "reference": "e87a786e3ae12a25cf78a71bb07b4b384bfaa83a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/b334d6c5f95364948e06d2f620ab93d084074c6e",
-                "reference": "b334d6c5f95364948e06d2f620ab93d084074c6e",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/e87a786e3ae12a25cf78a71bb07b4b384bfaa83a",
+                "reference": "e87a786e3ae12a25cf78a71bb07b4b384bfaa83a",
                 "shasum": ""
             },
             "require": {
@@ -797,7 +1199,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2016-03-07 21:01:43"
+            "time": "2016-03-14 21:54:11"
         },
         {
             "name": "league/fractal",
@@ -864,16 +1266,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.18.0",
+            "version": "1.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "e19b764b5c855580e8ffa7e615f72c10fd2f99cc"
+                "reference": "a5f2734e8c16f3aa21b3da09715d10e15b4d2d45"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/e19b764b5c855580e8ffa7e615f72c10fd2f99cc",
-                "reference": "e19b764b5c855580e8ffa7e615f72c10fd2f99cc",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/a5f2734e8c16f3aa21b3da09715d10e15b4d2d45",
+                "reference": "a5f2734e8c16f3aa21b3da09715d10e15b4d2d45",
                 "shasum": ""
             },
             "require": {
@@ -938,7 +1340,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2016-03-01 18:00:40"
+            "time": "2016-03-13 16:08:35"
         },
         {
             "name": "mtdowling/cron-expression",
@@ -1084,16 +1486,16 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v1.2.1",
+            "version": "v1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "f078eba3bcf140fd69b5fcc3ea5ac809abf729dc"
+                "reference": "c7e26a21ba357863de030f0b9e701c7d04593774"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/f078eba3bcf140fd69b5fcc3ea5ac809abf729dc",
-                "reference": "f078eba3bcf140fd69b5fcc3ea5ac809abf729dc",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/c7e26a21ba357863de030f0b9e701c7d04593774",
+                "reference": "c7e26a21ba357863de030f0b9e701c7d04593774",
                 "shasum": ""
             },
             "require": {
@@ -1128,7 +1530,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2016-02-29 17:25:04"
+            "time": "2016-03-18 20:34:03"
         },
         {
             "name": "predis/predis",
@@ -2792,16 +3194,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.23",
+            "version": "4.8.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6e351261f9cd33daf205a131a1ba61c6d33bd483"
+                "reference": "a1066c562c52900a142a0e2bbf0582994671385e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6e351261f9cd33daf205a131a1ba61c6d33bd483",
-                "reference": "6e351261f9cd33daf205a131a1ba61c6d33bd483",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a1066c562c52900a142a0e2bbf0582994671385e",
+                "reference": "a1066c562c52900a142a0e2bbf0582994671385e",
                 "shasum": ""
             },
             "require": {
@@ -2860,7 +3262,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-02-11 14:56:33"
+            "time": "2016-03-14 06:16:08"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -28,6 +28,5 @@ $factory->define(Contest::class, function (Generator $faker) {
     return [
         'campaign_id' => $faker->numberBetween(10, 300),
         'campaign_run_id' => $faker->numberBetween(1000, 3000),
-        'duration' => $faker->randomElement([30, 60, 365]),
     ];
 });

--- a/database/migrations/2016_03_22_175301_drop_contest_duration_column.php
+++ b/database/migrations/2016_03_22_175301_drop_contest_duration_column.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DropContestDurationColumn extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('contests', function ($table) {
+            $table->dropColumn('duration');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('contests', function (Blueprint $table) {
+            $table->integer('duration')->comment = 'The duration of a competition within this contest in units of days';
+        });
+    }
+}

--- a/resources/views/contests/index.blade.php
+++ b/resources/views/contests/index.blade.php
@@ -24,7 +24,6 @@
                                 <th class="table__cell">ID</th>
                                 <th class="table__cell">Campaign</th>
                                 <th class="table__cell">Campaign Run</th>
-                                <th class="table__cell">Duration</th>
                                 <th class="table__cell">Signup End Date</th>
                                 <th class="table__cell">Signups</th>
                                 <th class="table__cell">Waiting Room Status</th>
@@ -39,7 +38,6 @@
                                     <td class="table__cell"><a href="{{ route('contests.show', $contest->id) }}">{{ $contest->id }}</a></td>
                                     <td class="table__cell"><a href="{{ url(config('services.phoenix.uri') .'/node/' . $contest->campaign_id) }}">{{ $contest->campaign_id }}</a></td>
                                     <td class="table__cell">{{ $contest->campaign_run_id }}</td>
-                                    <td class="table__cell">{{ $contest->duration }}</td>
                                     <td class="table__cell">{{ $contest->waitingRoom->signup_end_date->format('F d, Y') }}</td>
                                     <td class="table__cell"><a href="{{ route('waitingrooms.show', $contest->waitingroom->id) }}">{{ $contest->waitingroom->users->count() }}</a></td>
                                     <td class="table__cell">

--- a/resources/views/contests/partials/_form_contest.blade.php
+++ b/resources/views/contests/partials/_form_contest.blade.php
@@ -22,9 +22,4 @@
     <input type="number" name="campaign_run_id" id="campaign_run_id" class="text-field" placeholder="42" value="{{ $contest->campaign_run_id or old('campaign_run_id') }}"/>
 </div>
 
-<div class="form-item -padded">
-    <label class="field-label" for="id">Duration (in days):</label>
-    <input type="number" name="duration" id="duration" class="text-field" placeholder="1" value="{{ $contest->duration or old('duration') }}"/>
-</div>
-
 <input type="submit" class="button" value="Submit" />

--- a/resources/views/contests/show.blade.php
+++ b/resources/views/contests/show.blade.php
@@ -13,7 +13,6 @@
                 <ul>
                     <li><strong>Campaign ID:</strong> {{ $contest->campaign_id }}</li>
                     <li><strong>Campaign Run ID:</strong> {{ $contest->campaign_run_id }}</li>
-                    <li><strong>Duration:</strong> {{ $contest->duration }}</li>
                 </ul>
             </div>
 

--- a/resources/views/waitingrooms/split.blade.php
+++ b/resources/views/waitingrooms/split.blade.php
@@ -9,12 +9,13 @@
     <div class="container">
         <div class="wrapper">
             <div class="container__block">
-                <h1>{{ count($split) . ' Proposed Competition(s)' }}</h1>
+                <h1>{{ count($split) . ' Proposed ' . ((count($split) === 1) ? 'Competition' : 'Competitions') }}</h1>
             </div>
             @if (count($split))
                 <form method="POST" action="{{ route('split', $room->id) }}">
                     {{ method_field('POST') }}
                     {{ csrf_field() }}
+
                     <div class="container__block">
                         <div class="form-item -padded">
                             <label class="field-label" for="competition_end_date">End date for these competitions:</label>

--- a/resources/views/waitingrooms/split.blade.php
+++ b/resources/views/waitingrooms/split.blade.php
@@ -6,38 +6,40 @@
         'title' => 'Waiting Room Banana Split'
     ])
 
-    <div class="container">
-        <div class="wrapper">
-            <div class="container__block -narrow">
-                <form method="POST" action="{{ route('split', $room->id) }}">
-                    {{ method_field('POST') }}
-                    {{ csrf_field() }}
+    <form method="POST" action="{{ route('split', $room->id) }}">
+        {{ method_field('POST') }}
+        {{ csrf_field() }}
+        <div class="container">
+            <div class="wrapper">
+                <div class="container__block -narrow">
+                    <div class="form-item -padded">
+                        <label class="field-label" for="competition_end_date">End date for these competitions:</label>
+                        <input type="date" name="competition_end_date" id="competition_end_date" value='MM/DD/YYYY' class="text-field"></input>
+                    </div>
 
                     <input type="submit" class="button" value="Split" />
-                </form>
-            </div>
+                </div>
 
-            <div class="container__block">
-                <h1>Proposed Competitions</h1>
-                <table class="table">
-                    <thead>
-                        <tr class="table__header">
-                            <th class="table__cell">Competition</th>
-                            <th class="table__cell">Total Users</th>
-                            <th class="table__cell">Set End Date</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                       @foreach($split as $key => $competition)
-                            <tr class="table__row">
-                                <td class="table__cell">{{ $key + 1 }}</td>
-                                <td class="table__cell">{{ $competition->count() }}</td>
-                                <td class="table__cell">something</td>
+                <div class="container__block">
+                    <h1>Proposed Competitions</h1>
+                    <table class="table">
+                        <thead>
+                            <tr class="table__header">
+                                <th class="table__cell">Competition</th>
+                                <th class="table__cell">Total Users</th>
                             </tr>
-                        @endforeach
-                    </tbody>
-                </table>
+                        </thead>
+                        <tbody>
+                           @foreach($split as $key => $competition)
+                                <tr class="table__row">
+                                    <td class="table__cell">{{ $key + 1 }}</td>
+                                    <td class="table__cell">{{ count($competition) }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div>
-    </div>
+    </form>
 @stop

--- a/resources/views/waitingrooms/split.blade.php
+++ b/resources/views/waitingrooms/split.blade.php
@@ -16,9 +16,28 @@
                     <input type="submit" class="button" value="Split" />
                 </form>
             </div>
+
+            <div class="container__block">
+                <h1>Proposed Competitions</h1>
+                <table class="table">
+                    <thead>
+                        <tr class="table__header">
+                            <th class="table__cell">Competition</th>
+                            <th class="table__cell">Total Users</th>
+                            <th class="table__cell">Set End Date</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                       @foreach($split as $key => $competition)
+                            <tr class="table__row">
+                                <td class="table__cell">{{ $key + 1 }}</td>
+                                <td class="table__cell">{{ $competition->count() }}</td>
+                                <td class="table__cell">something</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
-    @foreach($split as $key => $competition)
-        @include('users.partials._table_users', ['users' => $competition, 'role' => 'Competition ' . ($key + 1) . ' : ' . $competition->count() . ' users'])
-    @endforeach
 @stop

--- a/resources/views/waitingrooms/split.blade.php
+++ b/resources/views/waitingrooms/split.blade.php
@@ -16,20 +16,9 @@
                     <input type="submit" class="button" value="Split" />
                 </form>
             </div>
-            <div class="container__block container__competitions">
-                <h1>Competitions</h1>
-                @foreach($split as $competition)
-                    <div class="container__split">
-                        <h1>{{ count($competition) }} Users</h1>
-                        <ul>
-                            @foreach($competition as $user)
-                                <li>{{ $user }}</li>
-                            @endforeach
-                        </ul>
-                    </div>
-                @endforeach
-            </div>
         </div>
     </div>
-
+    @foreach($split as $key => $competition)
+        @include('users.partials._table_users', ['users' => $competition, 'role' => 'Competition ' . ($key + 1) . ' : ' . $competition->count() . ' users'])
+    @endforeach
 @stop

--- a/resources/views/waitingrooms/split.blade.php
+++ b/resources/views/waitingrooms/split.blade.php
@@ -21,7 +21,7 @@
                 </div>
 
                 <div class="container__block">
-                    <h1>Proposed Competitions</h1>
+                    <h1>{{ count($split) . ' Proposed Competition(s)' }}</h1>
                     <table class="table">
                         <thead>
                             <tr class="table__header">

--- a/resources/views/waitingrooms/split.blade.php
+++ b/resources/views/waitingrooms/split.blade.php
@@ -6,40 +6,44 @@
         'title' => 'Waiting Room Banana Split'
     ])
 
-    <form method="POST" action="{{ route('split', $room->id) }}">
-        {{ method_field('POST') }}
-        {{ csrf_field() }}
-        <div class="container">
-            <div class="wrapper">
-                <div class="container__block -narrow">
-                    <div class="form-item -padded">
-                        <label class="field-label" for="competition_end_date">End date for these competitions:</label>
-                        <input type="date" name="competition_end_date" id="competition_end_date" value='MM/DD/YYYY' class="text-field"></input>
+    <div class="container">
+        <div class="wrapper">
+            <div class="container__block">
+                <h1>{{ count($split) . ' Proposed Competition(s)' }}</h1>
+            </div>
+            @if (count($split))
+                <form method="POST" action="{{ route('split', $room->id) }}">
+                    {{ method_field('POST') }}
+                    {{ csrf_field() }}
+                    <div class="container__block">
+                        <div class="form-item -padded">
+                            <label class="field-label" for="competition_end_date">End date for these competitions:</label>
+                            <input type="date" name="competition_end_date" id="competition_end_date" value='MM/DD/YYYY' class="text-field"></input>
+                        </div>
+
+                        <input type="submit" class="button" value="Split" />
                     </div>
 
-                    <input type="submit" class="button" value="Split" />
-                </div>
-
-                <div class="container__block">
-                    <h1>{{ count($split) . ' Proposed Competition(s)' }}</h1>
-                    <table class="table">
-                        <thead>
-                            <tr class="table__header">
-                                <th class="table__cell">Competition</th>
-                                <th class="table__cell">Total Users</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                           @foreach($split as $key => $competition)
-                                <tr class="table__row">
-                                    <td class="table__cell">{{ $key + 1 }}</td>
-                                    <td class="table__cell">{{ count($competition) }}</td>
+                    <div class="container__block">
+                        <table class="table">
+                            <thead>
+                                <tr class="table__header">
+                                    <th class="table__cell">Competition</th>
+                                    <th class="table__cell"># of Contestants</th>
                                 </tr>
-                            @endforeach
-                        </tbody>
-                    </table>
-                </div>
-            </div>
+                            </thead>
+                            <tbody>
+                               @foreach($split as $key => $competition)
+                                    <tr class="table__row">
+                                        <td class="table__cell">{{ $key }}</td>
+                                        <td class="table__cell">{{ count($competition) }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </form>
+            @endif
         </div>
-    </form>
+    </div>
 @stop


### PR DESCRIPTION
#### What's this PR do?
* Removed the duration field on contests and all references to the duration field. 
* Add field to split form that admins can use to set the end date for competitions when they do a split. Also added all the validation, split logic updates to accommodate this. 
* Updated the split form view a bit. It didn't seem useful to list all of the users in each competition at this point in the flow, but I can either add this back in later if folks really need it, or we can maybe link out to another view that has a list of all the users. 

The new split view looks like this:

<img width="913" alt="screen shot 2016-03-23 at 2 43 08 pm" src="https://cloud.githubusercontent.com/assets/1700409/13996790/9c60c032-f105-11e5-8111-d7d0567bcc17.png">

![serena-split](https://cloud.githubusercontent.com/assets/1700409/13996526/8f619d4e-f104-11e5-9b9a-da3f4a3e9f05.gif)


#### How should this be manually tested?
Pull down this branch 
Run `composer update` to get the `doctrine/dbal` package
Run `php artisan:migrate` to do the db updates
Check that duration field is gone-zo.

Then go to split a waiting room, 
you should be able to set a date that is after today as the end date for the competitions.

#### Any background context you want to provide?

NOTE: The `doctrine/dbal` package is [required in order to do column drops](https://laravel.com/docs/5.2/migrations#dropping-columns).
 
![674702c838b](https://cloud.githubusercontent.com/assets/1700409/13996609/f71e3f32-f104-11e5-8938-9e19432b9374.gif)

#### What are the relevant tickets?
Fixes #94 

@angaither @weerd @deadlybutter 