### PR TITLE
Update to fix bug with missing method if no password provided.

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -51,7 +51,7 @@ class Handler extends ExceptionHandler
         }
 
         if ($e instanceof ValidationException) {
-            return redirect()->back()->withInput($request->input())->withErrors($e->validator->getMessages());
+            return redirect()->back()->withInput($request->input())->withErrors($e->validator->messages());
         }
 
         if ($e instanceof NorthstarUserNotFoundException) {


### PR DESCRIPTION
#### What's this PR do?
This PR adds a simple fix to a bug when logging in without a password provided. The app throws an exception because when it handles the validation error, before returning to the page it tries to access the validation messages using an incorrect method.

#### How should this be manually tested?
Try logging in with an email and no password. Do you see crazy error-town or a proper validation error on the form indicating that a `password is required`?

#### What are the relevant tickets?
Fixes #139

---
@angaither @sbsmith86 @deadlybutter 
