### PR TITLE
Messaging in contest creation

### DIFF
--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -49,6 +49,10 @@ class ContestsController extends Controller
      */
     public function store(ContestRequest $request)
     {
+        dd($request->all());
+
+        // (new MessagesController)->store();
+
         $dateParams = ['signup_start_date', 'signup_end_date'];
 
         $contest = Contest::create($request->except($dateParams));

--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -5,6 +5,7 @@ namespace Gladiator\Http\Controllers;
 use Gladiator\Models\Contest;
 use Gladiator\Services\Manager;
 use Gladiator\Http\Requests\ContestRequest;
+use Gladiator\Repositories\MessageRepository;
 
 class ContestsController extends Controller
 {
@@ -49,14 +50,15 @@ class ContestsController extends Controller
      */
     public function store(ContestRequest $request)
     {
-        dd($request->all());
+        $contest = Contest::create([
+            'campaign_id' => $request->input('campaign_id'),
+            'campaign_run_id' => $request->input('campaign_run_id'),
+        ]);
 
-        // (new MessagesController)->store();
+        $contest->waitingRoom->fill($request->only(['signup_start_date', 'signup_end_date']))->save();
 
-        $dateParams = ['signup_start_date', 'signup_end_date'];
-
-        $contest = Contest::create($request->except($dateParams));
-        $contest->WaitingRoom->fill($request->only($dateParams))->save();
+        $repository = new MessageRepository;
+        $repository->createMessagesForContest($contest, $request->input('messages'));
 
         return redirect()->action('ContestsController@show', $contest->id)->with('status', 'Contest has been saved!');
     }

--- a/app/Http/Utilities/DefaultMessage.php
+++ b/app/Http/Utilities/DefaultMessage.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Gladiator\Http\Utilities;
+
+class DefaultMessage
+{
+    /**
+     * Array of default messages.
+     * @var array
+     */
+    protected static $defaultMessages = [
+        'welcome' => [
+            '1' => [
+                'label' => 'Welcome',
+                'subject' => 'Welcome, [First Name]!',
+                'body' => "Woohoo, so glad you signed up for my [Campaign Name] competition, [First Name]! Feel free to get a head start on the competition and begin today. \n\rI will be in touch with you with more info in the next few days. Excited to watch you climb the leaderboard and crush the competition! \n\r[Name of Staff]",
+            ]
+        ],
+        'checkin' => [
+            '1' => [
+                'label' => 'Where are you? Check status',
+                'subject' => 'Is everything ok, [First Name]?',
+                'body' => "I noticed you didn’t send in a picture of your [reportback item] into the DoSomething site last update. Just wanted to see if everything is ok! Even if you can't hit your goal, just a few [reportback items] can make a huge difference! \n\rIf you are able, you still have until Sunday night for the next update! Take a picture and upload to our site right here [link to campaign]. \n\rNeed a little inspiration? Check out the photo below as a great example! Let me know if there’s any way I can help you, $%First Name%!",
+            ],
+        ],
+        'reminder' => [
+            '1' => [
+                'label' => 'Reminder for first submission due',
+                'subject' => 'Hey [First Name]!',
+                'body' => "Just wanted to send along some more info about the [Campaign Name] Competition you signed up for. The rules are simple: \n\r1. The more [Report Back Noun] [Report Back Verb], the higher you move up the leaderboard \n\r2. You must prove it by uploading a selfie, clearly showing you and all [Report Back Noun] [Report Back Verb] each Sunday night \n\r3. The competitor with the most [Report Back Noun] [Report Back Verb] by the competition deadline of [Competition End Date], wins $100 on an amex gift card. 2nd ­ $50, 3rd ­ $25 \n\rYour first update is due on [Leaderboard Day ­1] before 10pm est. If you have an update for me, and want to see yourself on [Leaderboard Day]’s leaderboard, simply click the blue icon below!",
+            ],
+            '2' => [
+                'label' => 'Reminder to submit v1',
+                'subject' => 'Do you have anymore [Report Back Noun]?',
+                'body' => "[First Name] ­\n\rYour next update is due [Leaderboard Day ­1] before 10pm est. If you want to see yourself on the leaderboard, simply click on the icon below, then upload a selfie clearly showing you and all [Report Back Noun] [Report Back Verb] On Monday, I will send you the updated standings. \n\rLet me know if I can help, [First Name]! \n\r[Name of Staff]",
+            ],
+            '3' => [
+                'label' => 'Reminder to submit v2',
+                'subject' => 'This Competition is Almost Over, [First Name]',
+                'body' => "The final deadline for this competition is this Sunday night before 10pm EST! \n\rReady to upload a selfie now showing all your [Report Back Noun] [Report Back Verb]? Click the icon below. \n\rLooking forward to seeing your final pic, [First Name]!",
+            ],
+            '4' => [
+                'label' => 'Last minute reminder v1',
+                'subject' => 'Send us your [Campaign Name] Competition Photo!',
+                'body' => "[First Name]! \n\rThis is your friendly reminder that your next update is due tonight at 10pm est, so if you want to make the leaderboard and see your name featured, upload your selfie with all your [Report Back Noun] [Report Back Verb]. \n\rCan’t wait to see it! \n\r[Name of Staff]",
+            ],
+            '5' => [
+                'label' => 'Last minute reminder v2',
+                'subject' => 'The Competition Deadline is Now!',
+                'body' => "You have until tonight at 10pm EST to upload your final, badass selfie with all of your [Report Back Noun]. \n\rUpload your final selfie with your [Report Back Noun] below. Can’t wait to see how you did, [First Name]!",
+            ],
+        ],
+        'leaderboard' => [
+            '1' => [
+                'label' => 'Leaderboard update',
+                'subject' => '1st Leaderboard Update',
+                'body' => "Hello Competitors, \n\rHere is your 1st official [Campaign Name] competition update! The competition ends on [Competition End Date]. Finish in the top 3 in [Report Back Noun] [Report Back Verb] and win: \n\r- 1st place ­ $100 amex card\r- 2nd place ­ $50 amex card \r- 3rd place ­ $25 amex card \n\rKeep collecting [Report Back Noun] for the next 2 weeks to move up the leaderboard! \n\rPro tip ­ [Contest Pro Tip] \n\rNext update selfie with your [Report Back Noun] will be due [Leaderboard Day ­ 1] before 10pm est. \n\rHere is the leaderboard! Top 3 and a shoutouts below: \n\r[Leaderboard] \n\r[1 Random Image w/ comment] \n\r[Top 3 competitor IMAGES w/comment] \n\r[#] more weeks to make your mark and climb up the leaderboard!",
+            ],
+            '2' => [
+                'label' => 'Final leaderboard update',
+                'subject' => 'The Results Are In!',
+                'body' => "This is it. The final leaderboard. Thank you for spending these last 3 weeks, battling not only to climb the leaderboard, but affecting so many lives around you in a truly impactful way. \n\rHere is your final leaderboard. Pics, prizes and honorable mentions below:",
+            ],
+        ],
+    ];
+
+    /**
+     * Get all default messages.
+     *
+     * @return array
+     */
+    public static function all()
+    {
+        return static::$defaultMessages;
+    }
+
+    /**
+     * Get a specific message message by type and key.
+     *
+     * @param  string $type
+     * @param  string $key
+     * @return array
+     */
+    public static function get($type, $key)
+    {
+        $messages = static::$defaultMessages;
+
+        return $messages[$type][$key];
+    }
+}

--- a/app/Http/Utilities/DefaultMessage.php
+++ b/app/Http/Utilities/DefaultMessage.php
@@ -14,7 +14,7 @@ class DefaultMessage
                 'label' => 'Welcome',
                 'subject' => 'Welcome, [First Name]!',
                 'body' => "Woohoo, so glad you signed up for my [Campaign Name] competition, [First Name]! Feel free to get a head start on the competition and begin today. \n\rI will be in touch with you with more info in the next few days. Excited to watch you climb the leaderboard and crush the competition! \n\r[Name of Staff]",
-            ]
+            ],
         ],
         'checkin' => [
             '1' => [

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -6,13 +6,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class Message extends Model
 {
+    protected $fillable = ['contest_id', 'type', 'key', 'label', 'subject', 'body'];
+
     /**
      * Array of available message types.
      *
      * @var array
      */
     protected static $types = [
-        'general',
+        'checkin',
         'leaderboard',
         'reminder',
         'welcome',

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -12,6 +12,7 @@ class Message extends Model
      * @var array
      */
     protected static $types = [
+        'general',
         'leaderboard',
         'reminder',
         'welcome',

--- a/app/Repositories/MessageRepository.php
+++ b/app/Repositories/MessageRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Gladiator\Repositories;
+
+use Gladiator\Models\Message;
+
+class MessageRepository
+{
+    /**
+     * Create a new message.
+     *
+     * @param  \Gladiator\Models\Contest $contest
+     * @param  array $data
+     * @return \Gladiator\Models\Message
+     */
+    public function create($contest, $data)
+    {
+        $message = new Message;
+        $message->type = $data['type'];
+        $message->key = $data['key'];
+        $message->subject = $data['subject'];
+        $message->body = $data['body'];
+
+        $contest->messages()->save($message);
+
+        return $message;
+    }
+
+    /**
+     * Create a series of messages for a contest based on an
+     * associative array of messages keyed on message type.
+     *
+     * @param  \Gladiator\Models\Contest $contest
+     * @param  array $messages
+     * @return void
+     */
+    public function createMessagesForContest($contest, $messages)
+    {
+        foreach ($messages as $type => $items) {
+            foreach ($items as $key => $data) {
+                $data['type'] = $type;
+                $data['key'] = $key;
+
+                $this->create($contest, $data);
+            }
+        }
+    }
+}

--- a/app/Repositories/MessageRepository.php
+++ b/app/Repositories/MessageRepository.php
@@ -15,15 +15,9 @@ class MessageRepository
      */
     public function create($contest, $data)
     {
-        $message = new Message;
-        $message->type = $data['type'];
-        $message->key = $data['key'];
-        $message->subject = $data['subject'];
-        $message->body = $data['body'];
+        $message = new Message($data);
 
-        $contest->messages()->save($message);
-
-        return $message;
+        return $contest->messages()->save($message);
     }
 
     /**

--- a/database/migrations/2016_03_22_175301_drop_contest_duration_column.php
+++ b/database/migrations/2016_03_22_175301_drop_contest_duration_column.php
@@ -12,7 +12,7 @@ class DropContestDurationColumn extends Migration
      */
     public function up()
     {
-        Schema::table('contests', function ($table) {
+        Schema::table('contests', function (Blueprint $table) {
             $table->dropColumn('duration');
         });
     }

--- a/database/migrations/2016_03_28_191909_add_key_and_label_columns_to_messages_table.php
+++ b/database/migrations/2016_03_28_191909_add_key_and_label_columns_to_messages_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddKeyAndLabelColumnsToMessagesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('messages', function ($table) {
+            $table->integer('key')->unsigned()->after('type');
+            $table->string('label')->nullable()->after('key');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('messages', function ($table) {
+            $table->dropColumn('key');
+            $table->dropColumn('label');
+        });
+    }
+}

--- a/database/migrations/2016_03_28_191909_add_key_and_label_columns_to_messages_table.php
+++ b/database/migrations/2016_03_28_191909_add_key_and_label_columns_to_messages_table.php
@@ -12,7 +12,7 @@ class AddKeyAndLabelColumnsToMessagesTable extends Migration
      */
     public function up()
     {
-        Schema::table('messages', function ($table) {
+        Schema::table('messages', function (Blueprint $table) {
             $table->integer('key')->unsigned()->after('type');
             $table->string('label')->nullable()->after('key');
         });
@@ -25,7 +25,7 @@ class AddKeyAndLabelColumnsToMessagesTable extends Migration
      */
     public function down()
     {
-        Schema::table('messages', function ($table) {
+        Schema::table('messages', function (Blueprint $table) {
             $table->dropColumn('key');
             $table->dropColumn('label');
         });

--- a/database/migrations/2016_03_28_192628_add_sender_column_to_contests_table.php
+++ b/database/migrations/2016_03_28_192628_add_sender_column_to_contests_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddSenderColumnToContestsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('contests', function ($table) {
+            $table->string('sender')->nullable()->after('campaign_run_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('contests', function ($table) {
+            $table->dropColumn('sender');
+        });
+    }
+}

--- a/database/migrations/2016_03_28_192628_add_sender_column_to_contests_table.php
+++ b/database/migrations/2016_03_28_192628_add_sender_column_to_contests_table.php
@@ -12,7 +12,7 @@ class AddSenderColumnToContestsTable extends Migration
      */
     public function up()
     {
-        Schema::table('contests', function ($table) {
+        Schema::table('contests', function (Blueprint $table) {
             $table->string('sender')->nullable()->after('campaign_run_id');
         });
     }
@@ -24,7 +24,7 @@ class AddSenderColumnToContestsTable extends Migration
      */
     public function down()
     {
-        Schema::table('contests', function ($table) {
+        Schema::table('contests', function (Blueprint $table) {
             $table->dropColumn('sender');
         });
     }

--- a/resources/views/contests/create.blade.php
+++ b/resources/views/contests/create.blade.php
@@ -20,22 +20,23 @@
 
                     <h2 class="heading -alpha">Messaging Settings</h2>
 
-                    @include('contests.partials._form_contest_messaging', ['type' => 'welcome', 'name' => 'general'])
+                    @include('contests.partials._form_contest_messaging', ['type' => 'welcome', 'key' => '1', 'label' => 'Welcome'])
 
-                    @include('contests.partials._form_contest_messaging', ['type' => 'reminder', 'name' => 'first'])
+                    @include('contests.partials._form_contest_messaging', ['type' => 'checkin', 'key' => '1', 'label' => 'Where are you? Check status'])
 
-                    @include('contests.partials._form_contest_messaging', ['type' => 'reminder', 'name' => 'general_v1'])
+                    @include('contests.partials._form_contest_messaging', ['type' => 'reminder', 'key' => '1', 'label' => 'Reminder for first submission due'])
 
-                    @include('contests.partials._form_contest_messaging', ['type' => 'reminder', 'name' => 'general_v2'])
+                    @include('contests.partials._form_contest_messaging', ['type' => 'reminder', 'key' => '2', 'label' => 'Reminder to submit v1'])
 
-                    @include('contests.partials._form_contest_messaging', ['type' => 'reminder', 'name' => 'last'])
+                    @include('contests.partials._form_contest_messaging', ['type' => 'reminder', 'key' => '3', 'label' => 'Reminder to submit v2'])
 
-                    @include('contests.partials._form_contest_messaging', ['type' => 'general', 'name' => 'checkin'])
+                    @include('contests.partials._form_contest_messaging', ['type' => 'reminder', 'key' => '4', 'label' => 'Last minute reminder v1'])
 
-                    @include('contests.partials._form_contest_messaging', ['type' => 'leaderboard', 'name' => 'update'])
+                    @include('contests.partials._form_contest_messaging', ['type' => 'reminder', 'key' => '5', 'label' => 'Last minute reminder v2'])
 
-                    @include('contests.partials._form_contest_messaging', ['type' => 'leaderboard', 'name' => 'final'])
+                    @include('contests.partials._form_contest_messaging', ['type' => 'leaderboard', 'key' => '1', 'label' => 'Leaderboard update'])
 
+                    @include('contests.partials._form_contest_messaging', ['type' => 'leaderboard', 'key' => '2', 'label' => 'Final leaderboard update'])
 
                     <input type="submit" class="button" value="Submit" />
                 </form>

--- a/resources/views/contests/create.blade.php
+++ b/resources/views/contests/create.blade.php
@@ -1,3 +1,5 @@
+@inject('defaultMessage', 'Gladiator\Http\Utilities\DefaultMessage')
+
 @extends('layouts.master')
 
 @section('main_content')
@@ -20,23 +22,23 @@
 
                     <h2 class="heading -alpha">Messaging Settings</h2>
 
-                    @include('contests.partials._form_contest_messaging', ['type' => 'welcome', 'key' => '1', 'label' => 'Welcome'])
+                    @include('contests.partials._form_contest_messaging', ['default' => $defaultMessage->get('welcome', '1'), 'type' => 'welcome', 'key' => '1'])
 
-                    @include('contests.partials._form_contest_messaging', ['type' => 'checkin', 'key' => '1', 'label' => 'Where are you? Check status'])
+                    @include('contests.partials._form_contest_messaging', ['default' => $defaultMessage->get('checkin', '1'), 'type' => 'checkin', 'key' => '1'])
 
-                    @include('contests.partials._form_contest_messaging', ['type' => 'reminder', 'key' => '1', 'label' => 'Reminder for first submission due'])
+                    @include('contests.partials._form_contest_messaging', ['default' => $defaultMessage->get('reminder', '1'), 'type' => 'reminder', 'key' => '1'])
 
-                    @include('contests.partials._form_contest_messaging', ['type' => 'reminder', 'key' => '2', 'label' => 'Reminder to submit v1'])
+                    @include('contests.partials._form_contest_messaging', ['default' => $defaultMessage->get('reminder', '2'), 'type' => 'reminder', 'key' => '2'])
 
-                    @include('contests.partials._form_contest_messaging', ['type' => 'reminder', 'key' => '3', 'label' => 'Reminder to submit v2'])
+                    @include('contests.partials._form_contest_messaging', ['default' => $defaultMessage->get('reminder', '3'), 'type' => 'reminder', 'key' => '3'])
 
-                    @include('contests.partials._form_contest_messaging', ['type' => 'reminder', 'key' => '4', 'label' => 'Last minute reminder v1'])
+                    @include('contests.partials._form_contest_messaging', ['default' => $defaultMessage->get('reminder', '4'), 'type' => 'reminder', 'key' => '4'])
 
-                    @include('contests.partials._form_contest_messaging', ['type' => 'reminder', 'key' => '5', 'label' => 'Last minute reminder v2'])
+                    @include('contests.partials._form_contest_messaging', ['default' => $defaultMessage->get('reminder', '5'), 'type' => 'reminder', 'key' => '5'])
 
-                    @include('contests.partials._form_contest_messaging', ['type' => 'leaderboard', 'key' => '1', 'label' => 'Leaderboard update'])
+                    @include('contests.partials._form_contest_messaging', ['default' => $defaultMessage->get('leaderboard', '1'), 'type' => 'leaderboard', 'key' => '1'])
 
-                    @include('contests.partials._form_contest_messaging', ['type' => 'leaderboard', 'key' => '2', 'label' => 'Final leaderboard update'])
+                    @include('contests.partials._form_contest_messaging', ['default' => $defaultMessage->get('leaderboard', '2'), 'type' => 'leaderboard', 'key' => '2'])
 
                     <input type="submit" class="button" value="Submit" />
                 </form>

--- a/resources/views/contests/create.blade.php
+++ b/resources/views/contests/create.blade.php
@@ -11,7 +11,33 @@
         <div class="wrapper">
             <div class="container__block -narrow">
                 <form method="POST" action="{{ route('contests.store') }}">
+                    {{ csrf_field() }}
+
+                    <h2 class="heading -alpha">Settings</h2>
+
                     @include('contests.partials._form_contest')
+
+
+                    <h2 class="heading -alpha">Messaging Settings</h2>
+
+                    @include('contests.partials._form_contest_messaging', ['type' => 'welcome', 'name' => 'general'])
+
+                    @include('contests.partials._form_contest_messaging', ['type' => 'reminder', 'name' => 'first'])
+
+                    @include('contests.partials._form_contest_messaging', ['type' => 'reminder', 'name' => 'general_v1'])
+
+                    @include('contests.partials._form_contest_messaging', ['type' => 'reminder', 'name' => 'general_v2'])
+
+                    @include('contests.partials._form_contest_messaging', ['type' => 'reminder', 'name' => 'last'])
+
+                    @include('contests.partials._form_contest_messaging', ['type' => 'general', 'name' => 'checkin'])
+
+                    @include('contests.partials._form_contest_messaging', ['type' => 'leaderboard', 'name' => 'update'])
+
+                    @include('contests.partials._form_contest_messaging', ['type' => 'leaderboard', 'name' => 'final'])
+
+
+                    <input type="submit" class="button" value="Submit" />
                 </form>
             </div>
         </div>

--- a/resources/views/contests/partials/_form_contest.blade.php
+++ b/resources/views/contests/partials/_form_contest.blade.php
@@ -1,7 +1,5 @@
 @include('layouts.errors')
 
-{{ csrf_field() }}
-
 <div class="form-item -padded">
     <label class="field-label" for="signup_start_date">Signup Start Date:</label>
     <input type="date" name="signup_start_date" id="signup_start_date" value={{ $contest->waitingRoom->signup_start_date or old('signup_start_date', 'MM/DD/YYYY')}} class="text-field"></input>
@@ -21,5 +19,3 @@
     <label class="field-label" for="id">Campaign Run ID:</label>
     <input type="number" name="campaign_run_id" id="campaign_run_id" class="text-field" placeholder="42" value="{{ $contest->campaign_run_id or old('campaign_run_id') }}"/>
 </div>
-
-<input type="submit" class="button" value="Submit" />

--- a/resources/views/contests/partials/_form_contest_messaging.blade.php
+++ b/resources/views/contests/partials/_form_contest_messaging.blade.php
@@ -12,4 +12,6 @@
         <label class="field-label" for="messages[{{ $type }}][{{ $key }}][body]">Body:</label>
         <textarea class="text-field" name="messages[{{ $type }}][{{ $key }}][body]" id="messages[{{ $type }}][{{ $key }}][body]" rows="10"></textarea>
     </div>
+
+    <input type="hidden" name="messages[{{ $type }}][{{ $key }}][label]" value="{{ $label }}" />
 </fieldset>

--- a/resources/views/contests/partials/_form_contest_messaging.blade.php
+++ b/resources/views/contests/partials/_form_contest_messaging.blade.php
@@ -1,17 +1,17 @@
 @include('layouts.errors')
 
 <fieldset>
-    <h3 class="heading">{{ $label }} email:</h3>
+    <h3 class="heading">{{ $default['label'] }} email:</h3>
 
     <div class="form-item -padded">
         <label class="field-label" for="messages[{{ $type }}][{{ $key }}][subject]">Subject:</label>
-        <input class="text-field" type="text" name="messages[{{ $type }}][{{ $key }}][subject]" id="messages[{{ $type }}][{{ $key }}][subject]" value="" />
+        <input class="text-field" type="text" name="messages[{{ $type }}][{{ $key }}][subject]" id="messages[{{ $type }}][{{ $key }}][subject]" value="{{ $default['subject'] }}" />
     </div>
 
     <div class="form-item -padded">
         <label class="field-label" for="messages[{{ $type }}][{{ $key }}][body]">Body:</label>
-        <textarea class="text-field" name="messages[{{ $type }}][{{ $key }}][body]" id="messages[{{ $type }}][{{ $key }}][body]" rows="10"></textarea>
+        <textarea class="text-field" name="messages[{{ $type }}][{{ $key }}][body]" id="messages[{{ $type }}][{{ $key }}][body]" rows="10">{{ $default['body'] }}</textarea>
     </div>
 
-    <input type="hidden" name="messages[{{ $type }}][{{ $key }}][label]" value="{{ $label }}" />
+    <input type="hidden" name="messages[{{ $type }}][{{ $key }}][label]" value="{{ $default['label'] }}" />
 </fieldset>

--- a/resources/views/contests/partials/_form_contest_messaging.blade.php
+++ b/resources/views/contests/partials/_form_contest_messaging.blade.php
@@ -1,15 +1,15 @@
 @include('layouts.errors')
 
 <fieldset>
-    <h3 class="heading">{{ ucfirst($type) }} Email</h3>
+    <h3 class="heading">{{ $label }} email:</h3>
 
     <div class="form-item -padded">
-        <label class="field-label" for="messages[{{ $type }}][{{ $name }}][subject]">Subject:</label>
-        <input class="text-field" type="text" name="messages[{{ $type }}][{{ $name }}][subject]" id="messages[{{ $type }}][{{ $name }}][subject]" value="" />
+        <label class="field-label" for="messages[{{ $type }}][{{ $key }}][subject]">Subject:</label>
+        <input class="text-field" type="text" name="messages[{{ $type }}][{{ $key }}][subject]" id="messages[{{ $type }}][{{ $key }}][subject]" value="" />
     </div>
 
     <div class="form-item -padded">
-        <label class="field-label" for="messages[{{ $type }}][{{ $name }}][body]">Body:</label>
-        <textarea class="text-field" name="messages[{{ $type }}][{{ $name }}][body]" id="messages[{{ $type }}][{{ $name }}][body]" rows="10"></textarea>
+        <label class="field-label" for="messages[{{ $type }}][{{ $key }}][body]">Body:</label>
+        <textarea class="text-field" name="messages[{{ $type }}][{{ $key }}][body]" id="messages[{{ $type }}][{{ $key }}][body]" rows="10"></textarea>
     </div>
 </fieldset>

--- a/resources/views/contests/partials/_form_contest_messaging.blade.php
+++ b/resources/views/contests/partials/_form_contest_messaging.blade.php
@@ -1,0 +1,15 @@
+@include('layouts.errors')
+
+<fieldset>
+    <h3 class="heading">{{ ucfirst($type) }} Email</h3>
+
+    <div class="form-item -padded">
+        <label class="field-label" for="messages[{{ $type }}][{{ $name }}][subject]">Subject:</label>
+        <input class="text-field" type="text" name="messages[{{ $type }}][{{ $name }}][subject]" id="messages[{{ $type }}][{{ $name }}][subject]" value="" />
+    </div>
+
+    <div class="form-item -padded">
+        <label class="field-label" for="messages[{{ $type }}][{{ $name }}][body]">Body:</label>
+        <textarea class="text-field" name="messages[{{ $type }}][{{ $name }}][body]" id="messages[{{ $type }}][{{ $name }}][body]" rows="10"></textarea>
+    </div>
+</fieldset>


### PR DESCRIPTION
#### What's this PR do?
This PR allows creating the messages for a Contest when creating a new contest. When creating a new Contest, the message fields are pre-populated with some default content to simplify message creation.

#### How should this be manually tested?
Try creating a contest along with some messages. Make sure that all the messages are saved to the database with the correct `contest_id`.

#### Any background context you want to provide?
This currently only allows creating the messages when the contest is created, but not editing them. That it coming in an upcoming PR.

#### What are the relevant tickets?
Fixes #137

---
@angaither @sbsmith86 @deadlybutter 