### PR TITLE
Add contest sender field

### DIFF
--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -50,9 +50,11 @@ class ContestsController extends Controller
      */
     public function store(ContestRequest $request)
     {
+
         $contest = Contest::create([
             'campaign_id' => $request->input('campaign_id'),
             'campaign_run_id' => $request->input('campaign_run_id'),
+            'sender' => $request->input('sender'),
         ]);
 
         $contest->waitingRoom->fill($request->only(['signup_start_date', 'signup_end_date']))->save();

--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -50,7 +50,6 @@ class ContestsController extends Controller
      */
     public function store(ContestRequest $request)
     {
-
         $contest = Contest::create([
             'campaign_id' => $request->input('campaign_id'),
             'campaign_run_id' => $request->input('campaign_run_id'),

--- a/app/Http/Requests/ContestRequest.php
+++ b/app/Http/Requests/ContestRequest.php
@@ -24,6 +24,7 @@ class ContestRequest extends Request
         return [
             'campaign_id' => 'required|numeric',
             'campaign_run_id' => 'required|numeric',
+            'sender' => 'email',
             'signup_start_date' => 'required|date',
             'signup_end_date' => 'required|date',
         ];

--- a/app/Models/Contest.php
+++ b/app/Models/Contest.php
@@ -11,7 +11,7 @@ class Contest extends Model
      *
      * @var array
      */
-    protected $fillable = ['campaign_id', 'campaign_run_id'];
+    protected $fillable = ['campaign_id', 'campaign_run_id', 'sender'];
 
     /**
      * Get the waiting room associated with this contest.
@@ -53,5 +53,15 @@ class Contest extends Model
         }
 
         return buildCSV($data);
+    }
+
+    /**
+     * Set the sender attribute for the contest.
+     *
+     * @param string $value
+     */
+    public function setSenderAttribute($value)
+    {
+        $this->attributes['sender'] = ! empty($value) ? $value : null;
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -64,7 +64,7 @@ class User extends BaseUser
     }
 
     /**
-     * Set the role for the user.
+     * Set the role attribute for the user.
      *
      * @param  string  $value
      * @return string

--- a/resources/views/contests/edit.blade.php
+++ b/resources/views/contests/edit.blade.php
@@ -12,8 +12,11 @@
             <div class="container__block">
                 <form method="POST" action="{{ route('contests.update', $contest->id) }}">
                     {{ method_field('PATCH') }}
+                    {{ csrf_field() }}
 
                     @include('contests.partials._form_contest')
+
+                    <input type="submit" class="button" value="Submit" />
                 </form>
             </div>
         </div>

--- a/resources/views/contests/partials/_form_contest.blade.php
+++ b/resources/views/contests/partials/_form_contest.blade.php
@@ -19,3 +19,8 @@
     <label class="field-label" for="id">Campaign Run ID:</label>
     <input type="number" name="campaign_run_id" id="campaign_run_id" class="text-field" placeholder="42" value="{{ $contest->campaign_run_id or old('campaign_run_id') }}"/>
 </div>
+
+<div class="form-item -padded">
+    <label class="field-label" for="sender">Messages Sender:</label>
+    <input type="text" name="sender" id="sender" class="text-field" placeholder="kallark&#64;dosomething.org" />
+</div>

--- a/resources/views/contests/partials/_form_contest.blade.php
+++ b/resources/views/contests/partials/_form_contest.blade.php
@@ -22,5 +22,5 @@
 
 <div class="form-item -padded">
     <label class="field-label" for="sender">Messages Sender:</label>
-    <input type="text" name="sender" id="sender" class="text-field" placeholder="kallark&#64;dosomething.org" />
+    <input type="text" name="sender" id="sender" class="text-field" placeholder="kallark&#64;dosomething.org" value="{{ $contest->sender or old('sender') }}" />
 </div>


### PR DESCRIPTION
#### What's this PR do?
This PR adds a "sender" field to the Contest creation form. It allows providing the Contest an email address that can later be used as the sender for the mail messages to contestants. It is _not_ required on initial Contest creation, and allows you to add a sender when you edit the Contest.

#### How should this be manually tested?
Try creating a contest and saving an email to the **Messages Sender** field! Then edit that contest and make sure the value you entered shows up in the field too :dancer: 

#### What are the relevant tickets?
Fixes #143

---
@angaither @sbsmith86 @deadlybutter 