### PR TITLE
Remove users from competition

### DIFF
--- a/app/Http/Controllers/CompetitionsController.php
+++ b/app/Http/Controllers/CompetitionsController.php
@@ -108,10 +108,9 @@ class CompetitionsController extends Controller
      * @param  \Gladiator\Models\Competition  $competition
      * @return \League\Csv\ $csv
      */
-    public function removeUser($competition_id, $user_id)
+    public function removeUser($competition_id, User $user)
     {
-        $user = User::find($user_id);
         $user->competitions()->detach($competition_id);
-        // return back with message.
+        return redirect()->back()->with('status', 'User was removed from competition ' . $competition_id);
     }
 }

--- a/app/Http/Controllers/CompetitionsController.php
+++ b/app/Http/Controllers/CompetitionsController.php
@@ -103,14 +103,15 @@ class CompetitionsController extends Controller
     }
 
     /**
-     * Download the CSV export of all users.
+     * Detach a user from a competition.
      *
      * @param  \Gladiator\Models\Competition  $competition
-     * @return \League\Csv\ $csv
+     * @param  \Gladiator\Models\User  $user
+     * @return \Illuminate\Http\Response
      */
-    public function removeUser($competition_id, User $user)
+    public function removeUser(Competition $competition, User $user)
     {
-        $user->competitions()->detach($competition_id);
-        return redirect()->back()->with('status', 'User was removed from competition ' . $competition_id);
+        $user->competitions()->detach($competition->id);
+        return redirect()->back()->with('status', 'User was removed from competition ' . $competition->id);
     }
 }

--- a/app/Http/Controllers/CompetitionsController.php
+++ b/app/Http/Controllers/CompetitionsController.php
@@ -7,6 +7,7 @@ use Gladiator\Models\Competition;
 use Gladiator\Models\Contest;
 use Gladiator\Repositories\UserRepositoryContract;
 use Gladiator\Services\Manager;
+use Gladiator\Models\User;
 
 class CompetitionsController extends Controller
 {
@@ -99,5 +100,18 @@ class CompetitionsController extends Controller
     {
         $csv = $this->manager->exportCSV($competition, true);
         $csv->output('competition' . $competition->id . '.csv');
+    }
+
+    /**
+     * Download the CSV export of all users.
+     *
+     * @param  \Gladiator\Models\Competition  $competition
+     * @return \League\Csv\ $csv
+     */
+    public function removeUser($competition_id, $user_id)
+    {
+        $user = User::find($user_id);
+        $user->competitions()->detach($competition_id);
+        // return back with message.
     }
 }

--- a/app/Http/Controllers/CompetitionsController.php
+++ b/app/Http/Controllers/CompetitionsController.php
@@ -112,6 +112,7 @@ class CompetitionsController extends Controller
     public function removeUser(Competition $competition, User $user)
     {
         $user->competitions()->detach($competition->id);
+
         return redirect()->back()->with('status', 'User was removed from competition ' . $competition->id);
     }
 }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -26,7 +26,7 @@ Route::group(['middleware' => ['web']], function () {
     Route::model('competitions', 'Gladiator\Models\Competition');
     Route::get('competitions/{competitions}/export', 'CompetitionsController@export')->name('competitions.export');
     Route::resource('competitions', 'CompetitionsController', ['except' => ['index', 'create']]);
-    Route::get('competition/{competition_id}/users/{user_id}', 'CompetitionsController@removeUser')->name('competitions.users.destroy');
+    Route::get('competition/{competition_id}/users/{user}', 'CompetitionsController@removeUser')->name('competitions.users.destroy');
 
     // Competitions
     Route::model('contests', 'Gladiator\Models\Contest');

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -26,7 +26,7 @@ Route::group(['middleware' => ['web']], function () {
     Route::model('competitions', 'Gladiator\Models\Competition');
     Route::get('competitions/{competitions}/export', 'CompetitionsController@export')->name('competitions.export');
     Route::resource('competitions', 'CompetitionsController', ['except' => ['index', 'create']]);
-    Route::get('competition/{competition_id}/users/{user}', 'CompetitionsController@removeUser')->name('competitions.users.destroy');
+    Route::get('competition/{competition}/users/{user}', 'CompetitionsController@removeUser')->name('competitions.users.destroy');
 
     // Competitions
     Route::model('contests', 'Gladiator\Models\Contest');

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -26,6 +26,7 @@ Route::group(['middleware' => ['web']], function () {
     Route::model('competitions', 'Gladiator\Models\Competition');
     Route::get('competitions/{competitions}/export', 'CompetitionsController@export')->name('competitions.export');
     Route::resource('competitions', 'CompetitionsController', ['except' => ['index', 'create']]);
+    Route::get('competition/{competition_id}/users/{user_id}', 'CompetitionsController@removeUser')->name('competitions.users.destroy');
 
     // Competitions
     Route::model('contests', 'Gladiator\Models\Contest');

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -68,7 +68,7 @@
                                 <td class="table__cell">{{ $competition->reportback->quantity or 'N/A'}}</td>
                                 <td class="table__cell">{{ $competition->reportback->updated_at or 'N/A'}}</td>
                                 <td class="table__cell">{{ $competition->reportback->flagged or 'N/A' }}</td>
-                                <td class="table__cell"><a href="{{ route('competitions.users.destroy', ['user' => $user->id, 'competition_id' =>$competition->id]) }}" class="button -danger">Remove</a></td>
+                                <td class="table__cell"><a href="{{ route('competitions.users.destroy', ['user' => $user->id, 'competition' =>$competition->id]) }}" class="button -danger">Remove</a></td>
                             </tr>
                         @endforeach
                     </tbody>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -39,6 +39,7 @@
                             <th class="table__cell">Quantity</th>
                             <th class="table__cell">Updated At</th>
                             <th class="table__cell">Flagged</th>
+                            <th class="table__cell">Remove from Competition</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -67,6 +68,7 @@
                                 <td class="table__cell">{{ $competition->reportback->quantity or 'N/A'}}</td>
                                 <td class="table__cell">{{ $competition->reportback->updated_at or 'N/A'}}</td>
                                 <td class="table__cell">{{ $competition->reportback->flagged or 'N/A' }}</td>
+                                <td class="table__cell"><a href="{{ route('competitions.users.destroy', ['user_id' => $user->id, 'competition_id' =>$competition->id]) }}" class="button -danger">Remove</a></td>
                             </tr>
                         @endforeach
                     </tbody>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -68,7 +68,7 @@
                                 <td class="table__cell">{{ $competition->reportback->quantity or 'N/A'}}</td>
                                 <td class="table__cell">{{ $competition->reportback->updated_at or 'N/A'}}</td>
                                 <td class="table__cell">{{ $competition->reportback->flagged or 'N/A' }}</td>
-                                <td class="table__cell"><a href="{{ route('competitions.users.destroy', ['user_id' => $user->id, 'competition_id' =>$competition->id]) }}" class="button -danger">Remove</a></td>
+                                <td class="table__cell"><a href="{{ route('competitions.users.destroy', ['user' => $user->id, 'competition_id' =>$competition->id]) }}" class="button -danger">Remove</a></td>
                             </tr>
                         @endforeach
                     </tbody>


### PR DESCRIPTION
#### What's this PR do?
Add functionality on the `user.show` page to remove a user from a competition

#### How should this be manually tested?
Pull down, and go to a user show page, hit remove. Is that pivot table record removed?

#### Any background context you want to provide?
This only removes the record in the pivot table, it doesn't remove the user from the database.
There's also no confirmation message before hitting this, that's why it's hidden all the way in the user show page. 

![image](https://cloud.githubusercontent.com/assets/645205/14150070/44c79e98-f675-11e5-97d1-e03687e2fc97.png)
![image](https://cloud.githubusercontent.com/assets/645205/14150076/4e6b5034-f675-11e5-9c2c-f9982b117bf8.png)


#### What are the relevant tickets?
Fixes #151 