### PR TITLE
Leaderboad email day

### DIFF
--- a/app/Http/Controllers/WaitingRoomsController.php
+++ b/app/Http/Controllers/WaitingRoomsController.php
@@ -132,7 +132,7 @@ class WaitingRoomsController extends Controller
     {
         $split = $room->getDefaultSplit();
         $contest = Contest::find($room->contest_id);
-        $room->saveSplit($contest, $split, $request->competition_end_date);
+        $room->saveSplit($contest, $split, $request);
 
         return redirect()->route('contests.show', $room->contest_id)->with('status', 'Waiting Room has been split!');
     }

--- a/app/Http/Requests/SplitRequest.php
+++ b/app/Http/Requests/SplitRequest.php
@@ -23,6 +23,7 @@ class SplitRequest extends Request
     {
         return [
             'competition_end_date' => 'required|date|after:today',
+            'leaderboard_msg_day' => 'required',
         ];
     }
 }

--- a/app/Models/WaitingRoom.php
+++ b/app/Models/WaitingRoom.php
@@ -88,11 +88,15 @@ class WaitingRoom extends Model
 
     /*
      * Creates competitions based on the given user split.
+     *
+     * @param \Gladiator\Models\Contest $contest
+     * @param Array                     $split
+     * @param \Illuminate\Http\Request  $request
      */
-    public function saveSplit($contest, $split, $endDate)
+    public function saveSplit($contest, $split, $request)
     {
         $startDate = Carbon::now()->startOfDay();
-        $endDate = new Carbon($endDate);
+        $endDate = new Carbon($request->competition_end_date);
 
         foreach ($split as $competitionGroup) {
             // For each split, create a competition.
@@ -101,7 +105,7 @@ class WaitingRoom extends Model
             $competition->contest_id = $contest->getKey();
             $competition->competition_start_date = $startDate;
             $competition->competition_end_date = $endDate->endOfDay();
-
+            $competition->leaderboard_msg_day = $request->leaderboard_msg_day;
             $contest->competitions()->save($competition);
 
             // For each user in this group

--- a/database/migrations/2016_03_30_155352_add_leaderboard_email_day.php
+++ b/database/migrations/2016_03_30_155352_add_leaderboard_email_day.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddLeaderboardEmailDay extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('competitions', function (Blueprint $table) {
+            $table->integer('leaderboard_msg_day')->nullable()->after('competition_end_date');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('competitions', function (Blueprint $table) {
+            $table->dropColumn('leaderboard_msg_day');
+        });
+    }
+}

--- a/resources/views/competitions/show.blade.php
+++ b/resources/views/competitions/show.blade.php
@@ -16,6 +16,7 @@
                     <li><strong>Contest ID:</strong> <a href="{{ route('contests.show', $competition->contest_id) }}">{{ $competition->contest_id }}</a></li>
                     <li><strong>Start Date:</strong> {{ $competition->competition_start_date->format('F d, Y') }}</li>
                     <li><strong>End Date:</strong> {{ $competition->competition_end_date->format('F d, Y') }}</li>
+                    <li><strong>Leaderboard Message Sends:</strong> {{ jddayofweek($competition->leaderboard_msg_day, 1) }}</li>
                 </ul>
             </div>
             <div class="container__block -half">

--- a/resources/views/waitingrooms/partials/_form_split.blade.php
+++ b/resources/views/waitingrooms/partials/_form_split.blade.php
@@ -1,0 +1,29 @@
+<form method="POST" action="{{ route('split', $room->id) }}">
+    {{ method_field('POST') }}
+    {{ csrf_field() }}
+
+    <div class="container__block">
+        <div class="form-item -padded">
+            <div class="form-item -padded">
+                <label class="field-label" for="competition_end_date">End date for these competitions:</label>
+                <input type="date" name="competition_end_date" id="competition_end_date" value='MM/DD/YYYY' class="text-field"></input>
+            </div>
+            <div class="form-item -padded">
+                <label class="field-label" for="leaderboard_msg_day">Send leaderboard message on:</label>
+                <div class="select">
+                    <select name="leaderboard_msg_day">
+                        <option value="1">Monday</option>
+                        <option value="2">Tuesday</option>
+                        <option value="3">Wednesday</option>
+                        <option value="4">Thursday</option>
+                        <option value="5">Friday</option>
+                        <option value="6">Saturday</option>
+                        <option value="7">Sunday</option>
+                    </select>
+                </div>
+            </div>
+        </div>
+
+        <input type="submit" class="button" value="Split" />
+    </div>
+</form>

--- a/resources/views/waitingrooms/partials/_form_split.blade.php
+++ b/resources/views/waitingrooms/partials/_form_split.blade.php
@@ -18,7 +18,7 @@
                         <option value="4">Thursday</option>
                         <option value="5">Friday</option>
                         <option value="6">Saturday</option>
-                        <option value="7">Sunday</option>
+                        <option value="0">Sunday</option>
                     </select>
                 </div>
             </div>

--- a/resources/views/waitingrooms/split.blade.php
+++ b/resources/views/waitingrooms/split.blade.php
@@ -12,38 +12,26 @@
                 <h1>{{ count($split) . ' Proposed ' . ((count($split) === 1) ? 'Competition' : 'Competitions') }}</h1>
             </div>
             @if (count($split))
-                <form method="POST" action="{{ route('split', $room->id) }}">
-                    {{ method_field('POST') }}
-                    {{ csrf_field() }}
+                @include('waitingrooms.partials._form_split')
 
-                    <div class="container__block">
-                        <div class="form-item -padded">
-                            <label class="field-label" for="competition_end_date">End date for these competitions:</label>
-                            <input type="date" name="competition_end_date" id="competition_end_date" value='MM/DD/YYYY' class="text-field"></input>
-                        </div>
-
-                        <input type="submit" class="button" value="Split" />
-                    </div>
-
-                    <div class="container__block">
-                        <table class="table">
-                            <thead>
-                                <tr class="table__header">
-                                    <th class="table__cell">Competition</th>
-                                    <th class="table__cell"># of Contestants</th>
+                <div class="container__block">
+                    <table class="table">
+                        <thead>
+                            <tr class="table__header">
+                                <th class="table__cell">Competition</th>
+                                <th class="table__cell"># of Contestants</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                           @foreach($split as $key => $competition)
+                                <tr class="table__row">
+                                    <td class="table__cell">{{ $key }}</td>
+                                    <td class="table__cell">{{ count($competition) }}</td>
                                 </tr>
-                            </thead>
-                            <tbody>
-                               @foreach($split as $key => $competition)
-                                    <tr class="table__row">
-                                        <td class="table__cell">{{ $key }}</td>
-                                        <td class="table__cell">{{ count($competition) }}</td>
-                                    </tr>
-                                @endforeach
-                            </tbody>
-                        </table>
-                    </div>
-                </form>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
             @endif
         </div>
     </div>


### PR DESCRIPTION
#### What's this PR do?
Adds a `leaderboard_msg_day` field to `competitions` and allows admins to set this field when splitting a waiting room.

#### How should this be manually tested?

Go to split a waiting room and you should see a new dropdown that allows you to set the day you want the leaderboard to be sent. You should be able to submit this form with no issues. 

#### What are the relevant tickets?
Fixes #145 