### PR TITLE
Some tokens and better routes

### DIFF
--- a/app/Events/QueueMessageRequest.php
+++ b/app/Events/QueueMessageRequest.php
@@ -3,6 +3,7 @@
 namespace Gladiator\Events;
 
 use Gladiator\Models\Message;
+use Gladiator\Models\Competition;
 use Illuminate\Queue\SerializesModels;
 
 class QueueMessageRequest extends Event
@@ -16,6 +17,7 @@ class QueueMessageRequest extends Event
      */
     public $message;
     public $sender;
+    public $competition;
 
     /**
      * Create a new event instance.
@@ -25,10 +27,11 @@ class QueueMessageRequest extends Event
      *
      * @return void
      */
-    public function __construct(Message $message, $sender)
+    public function __construct(Message $message, $sender, Competition $competition)
     {
         $this->message = $message;
         $this->sender = $sender;
+        $this->competition = $competition;
     }
 
     /**

--- a/app/Http/Controllers/CompetitionsController.php
+++ b/app/Http/Controllers/CompetitionsController.php
@@ -7,6 +7,7 @@ use Gladiator\Models\Competition;
 use Gladiator\Models\Contest;
 use Gladiator\Repositories\UserRepositoryContract;
 use Gladiator\Services\Manager;
+use Gladiator\Models\Message;
 use Gladiator\Models\User;
 
 class CompetitionsController extends Controller
@@ -114,5 +115,19 @@ class CompetitionsController extends Controller
         $user->competitions()->detach($competition->id);
 
         return redirect()->back()->with('status', 'User was removed from competition ' . $competition->id);
+    }
+
+        /**
+     * Detach a user from a competition.
+     *
+     * @param  \Gladiator\Models\Competition  $competition
+     * @param  \Gladiator\Models\Message  $message
+     * @return \Illuminate\Http\Response
+     */
+    public function message(Competition $competition, Contest $contest)
+    {
+        $messages = Message::where('contest_id', '=', $contest->id)->get();
+
+        return view('messages.show', compact('messages'));
     }
 }

--- a/app/Http/Controllers/CompetitionsController.php
+++ b/app/Http/Controllers/CompetitionsController.php
@@ -117,7 +117,7 @@ class CompetitionsController extends Controller
         return redirect()->back()->with('status', 'User was removed from competition ' . $competition->id);
     }
 
-        /**
+    /**
      * Detach a user from a competition.
      *
      * @param  \Gladiator\Models\Competition  $competition

--- a/app/Http/Controllers/CompetitionsController.php
+++ b/app/Http/Controllers/CompetitionsController.php
@@ -121,7 +121,7 @@ class CompetitionsController extends Controller
      * Detach a user from a competition.
      *
      * @param  \Gladiator\Models\Competition  $competition
-     * @param  \Gladiator\Models\Message  $message
+     * @param  \Gladiator\Models\Contest  $contest
      * @return \Illuminate\Http\Response
      */
     public function message(Competition $competition, Contest $contest)

--- a/app/Http/Controllers/CompetitionsController.php
+++ b/app/Http/Controllers/CompetitionsController.php
@@ -128,6 +128,6 @@ class CompetitionsController extends Controller
     {
         $messages = Message::where('contest_id', '=', $contest->id)->get();
 
-        return view('messages.show', compact('messages'));
+        return view('messages.show', compact('messages', 'competition'));
     }
 }

--- a/app/Http/Controllers/MessagesController.php
+++ b/app/Http/Controllers/MessagesController.php
@@ -78,10 +78,12 @@ class MessagesController extends Controller
     public static function sendMessage(Message $message)
     {
         $contest_id = request('contest_id');
+        $competition_id = request('competition_id');
+
         $from = Contest::find($contest_id)->sender;
 
         event(new QueueMessageRequest($message, $from));
 
-        return redirect()->route('messages.show', $contest_id)->with('status', 'Fired that right the hell off!');
+        return redirect()->route('competitions.message', ['competition' => $competition_id, 'contest' => $contest_id])->with('status', 'Fired that right the hell off!');
     }
 }

--- a/app/Http/Controllers/MessagesController.php
+++ b/app/Http/Controllers/MessagesController.php
@@ -4,6 +4,7 @@ namespace Gladiator\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Gladiator\Models\Contest;
+use Gladiator\Models\Competition;
 use Gladiator\Models\Message;
 use Gladiator\Events\QueueMessageRequest;
 use Gladiator\Repositories\MessageRepository;
@@ -81,8 +82,10 @@ class MessagesController extends Controller
         $competition_id = request('competition_id');
 
         $from = Contest::find($contest_id)->sender;
+        $competition = Competition::find($competition_id);
 
-        event(new QueueMessageRequest($message, $from));
+        //@TODO: only pass one thing in here instead of 3 or more.
+        event(new QueueMessageRequest($message, $from, $competition));
 
         return redirect()->route('competitions.message', ['competition' => $competition_id, 'contest' => $contest_id])->with('status', 'Fired that right the hell off!');
     }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -27,6 +27,7 @@ Route::group(['middleware' => ['web']], function () {
     Route::get('competitions/{competitions}/export', 'CompetitionsController@export')->name('competitions.export');
     Route::resource('competitions', 'CompetitionsController', ['except' => ['index', 'create']]);
     Route::get('competition/{competition}/users/{user}', 'CompetitionsController@removeUser')->name('competitions.users.destroy');
+    Route::get('competitions/{competitions}/messages/{contest}', 'CompetitionsController@message')->name('competitions.message');
 
     // Competitions
     Route::model('contests', 'Gladiator\Models\Contest');

--- a/app/Listeners/QueueMessage.php
+++ b/app/Listeners/QueueMessage.php
@@ -5,6 +5,7 @@ namespace Gladiator\Listeners;
 use Illuminate\Mail\Mailer;
 use Gladiator\Events\QueueMessageRequest;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Gladiator\Models\Message;
 
 class QueueMessage implements ShouldQueue
 {
@@ -28,7 +29,8 @@ class QueueMessage implements ShouldQueue
      */
     public function handle(QueueMessageRequest $event)
     {
-        $content = $event->message;
+        $content = Message::prepareMessage($event->message, $event->competition);
+
         $sender = $event->sender;
         $type = $content->type;
 

--- a/app/Models/Competition.php
+++ b/app/Models/Competition.php
@@ -21,6 +21,13 @@ class Competition extends Model
     protected $dates = ['competition_start_date', 'competition_end_date'];
 
     /**
+     * The attributes that can be tokenized.
+     *
+     * @var array
+     */
+    public static $tokenizable = ['competition_end_date', 'leaderboard_msg_day'];
+
+    /**
      * A Competition belongs to many Users.
      */
     public function users()

--- a/app/Models/Competition.php
+++ b/app/Models/Competition.php
@@ -35,4 +35,16 @@ class Competition extends Model
     {
         return $this->belongsTo(Contest::class);
     }
+
+   /**
+     * Get the leaderboard day of the week.
+     *
+     * @param  int  $value
+     * @return string
+     */
+    public function getLeaderboardMsgDayAttribute($value)
+    {
+        // Return day of the week as a string (Monday-Sunday).
+        return jddayofweek($value, 1);
+    }
 }

--- a/app/Models/Competition.php
+++ b/app/Models/Competition.php
@@ -43,7 +43,7 @@ class Competition extends Model
         return $this->belongsTo(Contest::class);
     }
 
-   /**
+    /**
      * Get the leaderboard day of the week.
      *
      * @param  int  $value

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -42,11 +42,9 @@ class Message extends Model
     {
         //@TODO: I only tested this with competition, is there other things we want to replace?
         $tokens = $model::$tokenizable;
-        foreach ($tokens as $token)
-        {
+        foreach ($tokens as $token) {
             $message->body = str_replace(':'.$token, $model->$token, $message->body);
-            //@TODO: handle the subject
-
+            //@TODO: handle the message subject.
         }
 
         return $message;

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -37,4 +37,18 @@ class Message extends Model
     {
         return static::$types;
     }
+
+    public static function prepareMessage($message, $model)
+    {
+        //@TODO: I only tested this with competition, is there other things we want to replace?
+        $tokens = $model::$tokenizable;
+        foreach ($tokens as $token)
+        {
+            $message->body = str_replace(':'.$token, $model->$token, $message->body);
+            //@TODO: handle the subject
+
+        }
+
+        return $message;
+    }
 }

--- a/resources/views/competitions/show.blade.php
+++ b/resources/views/competitions/show.blade.php
@@ -28,7 +28,7 @@
                         <a href="{{ route('competitions.export', $competition->id) }}" class="button">Export</a>
                     </li>
                     <li>
-                        <a href="{{ route('messages.show', $contest->id) }}" class="button">Email</a>
+                        <a href="{{ route('competitions.message', ['competition' => $competition->id,'contest' => $contest->id]) }}" class="button">Email</a>
                     </li>
 
                 </ul>

--- a/resources/views/contests/partials/_form_contest_messaging.blade.php
+++ b/resources/views/contests/partials/_form_contest_messaging.blade.php
@@ -1,5 +1,5 @@
 <fieldset>
-    <h3 class="heading">{{ $message['label'] }} email:</h3>
+    <h3 id={{ $message['type'] . $message['key'] }} class="heading">{{ $message['label'] }} email:</h3>
 
     <div class="form-item -padded">
         <label class="field-label" for="{{ correspondence()->getAttribute($message, 'subject') }}">Subject:</label>

--- a/resources/views/messages/show.blade.php
+++ b/resources/views/messages/show.blade.php
@@ -7,11 +7,10 @@
         'subtitle' => 'Viewing messages in contest ' . $messages[0]->contest_id
     ])
 
-
      <div class="container">
         <div class="wrapper">
             <div class="container__block">
-                <h2 class="heading -banner">Messages</h2>
+                <h2 class="heading -banner">Send Messages</h2>
                 <table class="table">
                     <thead>
                         <tr class="table__header">
@@ -24,7 +23,7 @@
                     <tbody>
                         @foreach ($messages as $message)
                             <tr class="table__row">
-                                <td class="table__cell">{{ $message->label or 'N/A'}}</td>
+                                <td class="table__cell"> <a href="{{ route('messages.edit', $message->contest_id)}}#{{ $message->type . $message->key }}">{{ $message->label or 'N/A'}}</a></td>
                                 <td class="table__cell">{{ $message->subject or 'N/A'}}</td>
                                 <td class="table__cell">{{ str_limit($message->body, 100) }}</td>
                                 <td class="table__cell"><a href="{{ route('messages.send', ['message' => $message->id, 'contest_id' => $message->contest_id, 'competition_id' => $competition->id]) }}" class="button -tertiary ">Send</a></td>

--- a/resources/views/messages/show.blade.php
+++ b/resources/views/messages/show.blade.php
@@ -3,7 +3,7 @@
 @section('main_content')
 
     @include('layouts.header', [
-        'title' => 'Competitions',
+        'title' => 'Competitions Messaging',
         'subtitle' => 'Viewing messages in contest ' . $messages[0]->contest_id
     ])
 
@@ -26,8 +26,8 @@
                             <tr class="table__row">
                                 <td class="table__cell">{{ $message->label or 'N/A'}}</td>
                                 <td class="table__cell">{{ $message->subject or 'N/A'}}</td>
-                                <td class="table__cell">{{ str_limit($message->body, 100)}}</td>
-                                <td class="table__cell"><a href="{{ route('messages.send', ['message' => $message->id, 'contest_id' => $message->contest_id]) }}" class="button -tertiary ">Send</a></td>
+                                <td class="table__cell">{{ ($message->body)}}</td>
+                                <td class="table__cell"><a href="{{ route('messages.send', ['message' => $message->id, 'contest_id' => $message->contest_id, 'competition_id' => $competition->id]) }}" class="button -tertiary ">Send</a></td>
                             </tr>
                         @endforeach
                     </tbody>

--- a/resources/views/messages/show.blade.php
+++ b/resources/views/messages/show.blade.php
@@ -26,7 +26,7 @@
                             <tr class="table__row">
                                 <td class="table__cell">{{ $message->label or 'N/A'}}</td>
                                 <td class="table__cell">{{ $message->subject or 'N/A'}}</td>
-                                <td class="table__cell">{{ ($message->body)}}</td>
+                                <td class="table__cell">{{ str_limit($message->body, 100) }}</td>
                                 <td class="table__cell"><a href="{{ route('messages.send', ['message' => $message->id, 'contest_id' => $message->contest_id, 'competition_id' => $competition->id]) }}" class="button -tertiary ">Send</a></td>
                             </tr>
                         @endforeach


### PR DESCRIPTION
#### What's this PR do?
- Creates `tokenizable` items on the competition
- Find and replace those tokens in messages
- Change the route you send messages from to include info about the competition
- Sets standard to look for `:token` all lowercase and all matching the name that stored in the db
  - this means some default message copy will need to be updated

#### How should this be manually tested?
- pull down, add some messages with `:token`s and watch them replace like magic before being delivered to your inbox.

#### Any background context you want to provide?
I only tested this with the few competitions tokens, not first names, not any phoenix data, figured we could get a proof of concept for this and go from there. 

#### What are the relevant tickets?
Refs #153  Refs #152 