### PR TITLE
Update sender and bug fixes

### DIFF
--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -50,7 +50,6 @@ class ContestsController extends Controller
      */
     public function store(ContestRequest $request)
     {
-        // dd($request->all());
         $contest = Contest::create([
             'campaign_id' => $request->input('campaign_id'),
             'campaign_run_id' => $request->input('campaign_run_id'),

--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -50,10 +50,12 @@ class ContestsController extends Controller
      */
     public function store(ContestRequest $request)
     {
+        // dd($request->all());
         $contest = Contest::create([
             'campaign_id' => $request->input('campaign_id'),
             'campaign_run_id' => $request->input('campaign_run_id'),
-            'sender' => $request->input('sender'),
+            'sender_email' => $request->input('sender_email'),
+            'sender_name' => $request->input('sender_name'),
         ]);
 
         $contest->waitingRoom->fill($request->only(['signup_start_date', 'signup_end_date']))->save();

--- a/app/Http/Requests/ContestRequest.php
+++ b/app/Http/Requests/ContestRequest.php
@@ -24,7 +24,8 @@ class ContestRequest extends Request
         return [
             'campaign_id' => 'required|numeric',
             'campaign_run_id' => 'required|numeric',
-            'sender' => 'email',
+            'sender_email' => 'email|required_with:sender_name',
+            'sender_name' => 'string|required_with:sender_email',
             'signup_start_date' => 'required|date',
             'signup_end_date' => 'required|date',
         ];

--- a/app/Models/Contest.php
+++ b/app/Models/Contest.php
@@ -11,7 +11,7 @@ class Contest extends Model
      *
      * @var array
      */
-    protected $fillable = ['campaign_id', 'campaign_run_id', 'sender'];
+    protected $fillable = ['campaign_id', 'campaign_run_id', 'sender_email', 'sender_name'];
 
     /**
      * Get the waiting room associated with this contest.
@@ -48,6 +48,7 @@ class Contest extends Model
         $competitions = $this->competitions;
 
         array_push($data, ['competition id']);
+
         foreach ($competitions as $competition) {
             array_push($data, [$competition->id]);
         }
@@ -56,12 +57,22 @@ class Contest extends Model
     }
 
     /**
-     * Set the sender attribute for the contest.
+     * Set the sender email attribute for the contest.
      *
      * @param string $value
      */
-    public function setSenderAttribute($value)
+    public function setSenderEmailAttribute($value)
     {
-        $this->attributes['sender'] = ! empty($value) ? $value : null;
+        $this->attributes['sender_email'] = ! empty($value) ? $value : null;
+    }
+
+    /**
+     * Set the sender name attribute for the contest.
+     *
+     * @param string $value
+     */
+    public function setSenderNameAttribute($value)
+    {
+        $this->attributes['sender_name'] = ! empty($value) ? $value : null;
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,5 +1,7 @@
 <?php
 
+use Carbon\Carbon;
+
 /**
  * Build a CSV from the supplied data.
  *
@@ -33,6 +35,32 @@ function correspondence($message = null, $field = null)
     }
 
     return $correspondence->get($message, $field);
+}
+
+/**
+ * Format a Carbon date if available to a simplified format
+ * for form input element. Uses old data if available.
+ *
+ * @param  \Illuminate\Database\Eloquent\Model  $model
+ * @param  string  $field
+ * @param  string  $defaut
+ * @return string
+ */
+function format_date_form_field($model, $field, $defaut = 'MM/DD/YYYY')
+{
+    $oldDate = old($field);
+
+    if ($oldDate) {
+        return $oldDate;
+    }
+
+    $attribute = $model->getAttribute($field);
+
+    if ($attribute && $attribute instanceof Carbon) {
+        return $attribute->format('Y-m-d');
+    }
+
+    return $default;
 }
 
 /**

--- a/database/migrations/2016_03_31_210841_rename_sender_column_to_sender_email_and_add_sender_name_column_to_contests_table.php
+++ b/database/migrations/2016_03_31_210841_rename_sender_column_to_sender_email_and_add_sender_name_column_to_contests_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RenameSenderColumnToSenderEmailAndAddSenderNameColumnToContestsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('contests', function (Blueprint $table) {
+            $table->string('sender_name')->nullable()->after('sender');
+            $table->renameColumn('sender', 'sender_email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('contests', function (Blueprint $table) {
+            $table->renameColumn('sender_email', 'sender');
+            $table->dropColumn('sender_name');
+        });
+    }
+}

--- a/resources/views/contests/create.blade.php
+++ b/resources/views/contests/create.blade.php
@@ -20,7 +20,7 @@
                     @include('contests.partials._form_contest')
 
 
-                    <h2 class="heading -alpha">Messaging Settings</h2>
+                    <h2 class="heading -alpha">Messages</h2>
 
                     @foreach (correspondence()->defaults() as $message)
 

--- a/resources/views/contests/edit.blade.php
+++ b/resources/views/contests/edit.blade.php
@@ -14,6 +14,8 @@
                     {{ method_field('PATCH') }}
                     {{ csrf_field() }}
 
+                    @include('layouts.errors')
+
                     @include('contests.partials._form_contest')
 
                     <input type="submit" class="button" value="Submit" />

--- a/resources/views/contests/partials/_form_contest.blade.php
+++ b/resources/views/contests/partials/_form_contest.blade.php
@@ -1,11 +1,11 @@
 <div class="form-item -padded">
     <label class="field-label" for="signup_start_date">Signup Start Date:</label>
-    <input type="date" name="signup_start_date" id="signup_start_date" class="text-field" value="{{ $contest->waitingRoom->signup_start_date or old('signup_start_date', 'MM/DD/YYYY') }}"></input>
+    <input type="date" name="signup_start_date" id="signup_start_date" class="text-field" value="{{ format_date_form_field($contest->waitingRoom, 'signup_start_date') }}"></input>
 </div>
 
 <div class="form-item -padded">
     <label class="field-label" for="signup_end_date">Signup End Date:</label>
-    <input type="date" name="signup_end_date" id="signup_end_date"  class="text-field" value="{{ $contest->waitingRoom->signup_end_date or old('signup_end_date', 'MM/DD/YYYY') }}"></input>
+    <input type="date" name="signup_end_date" id="signup_end_date"  class="text-field" value="{{ format_date_form_field($contest->waitingRoom, 'signup_end_date') }}"></input>
 </div>
 
 <div class="form-item -padded">
@@ -19,6 +19,11 @@
 </div>
 
 <div class="form-item -padded">
-    <label class="field-label" for="sender">Messages Sender:</label>
-    <input type="text" name="sender" id="sender" class="text-field" placeholder="kallark&#64;dosomething.org" value="{{ $contest->sender or old('sender') }}" />
+    <label class="field-label" for="sender_email">Messages Sender Email:</label>
+    <input type="text" name="sender_email" id="sender_email" class="text-field" placeholder="kallark&#64;dosomething.org" value="{{ $contest->sender_email or old('sender_email') }}" />
+</div>
+
+<div class="form-item -padded">
+    <label class="field-label" for="sender_name">Messages Sender Name:</label>
+    <input type="text" name="sender_name" id="sender_name" class="text-field" placeholder="Kallark" value="{{ $contest->sender_name or old('sender_name') }}" />
 </div>

--- a/resources/views/contests/show.blade.php
+++ b/resources/views/contests/show.blade.php
@@ -36,7 +36,8 @@
         <div class="wrapper">
             <div class="container__block">
                 <h2 class="heading -alpha">Messaging</h2>
-                <p>The current email assigned as the messages sender is: <em>{{ $contest->sender or 'not assigned' }}</em></p>
+                <p>The current name of the messages sender is: <em>{{ $contest->sender_name or 'not assigned' }}</em></p>
+                <p>The current email assigned for the messages sender is: <em>{{ $contest->sender_email or 'not assigned' }}</em></p>
                 <p><a href="{{ route('contests.messages.edit', $contest->id) }}" class="button -secondary">View &amp; Edit Messages</a></p>
             </div>
         </div>


### PR DESCRIPTION
#### What's this PR do?
This PR updates the database schema for the Contest model to change `sender` to `sender_email` and also include a `sender_name`. It updates the associated Contest forms to include adding values for those fields as well as updating them.

It also updates a complication with casting dates from the database to Carbon instances. It seems that all Carbon instances include the time as well as the date, and when passing this to the HTML5 `<input type="date" />` element. We only want to show a date on the form and not a datetime, so we had no need for the time, but it would still toss it into the field and cause issues if the `value` attribute had quotes or not (which is just weird behavior). So this PR adds a helper function for outputting dates to form fields that makes it a lot simpler and in the correct format.

#### How should this be manually tested?
Try creating/editing a contest and messing with the sender email and sender name fields.

#### Any background context you want to provide?
Screenshots of the weirdness with the inputs:

Without quotes, the time gets appended inside the input and just hangs there all weird like:
<img width="811" alt="screen shot 2016-04-01 at 1 31 55 pm" src="https://cloud.githubusercontent.com/assets/105849/14215959/366e49dc-f814-11e5-9620-d892ac9372bd.png">

With quotes, need to change the `date` type to a `datetime` for it to populate the field and show up, but we didn't want the time.
<img width="823" alt="screen shot 2016-04-01 at 1 32 04 pm" src="https://cloud.githubusercontent.com/assets/105849/14215963/38d0fec2-f814-11e5-976a-a3f352d8c886.png">

Shout out to @sbsmith86 for the help in talking through the weirdness with the date input fields to help figure out a solution :dancer: 

#### What are the relevant tickets?
Fixes #158

---
@DoSomething/gladiator 
