### PR TITLE
Update to allow seeding messages and also fix issue with helper function.

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -28,5 +28,7 @@ $factory->define(Contest::class, function (Generator $faker) {
     return [
         'campaign_id' => $faker->numberBetween(10, 300),
         'campaign_run_id' => $faker->numberBetween(1000, 3000),
+        'sender_email' => $faker->safeEmail(),
+        'sender_name' => $faker->name(),
     ];
 });

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -14,5 +14,6 @@ class DatabaseSeeder extends Seeder
         $this->call(ContestTableSeeder::class);
         $this->call(UserTableSeeder::class);
         $this->call(CompetitionTableSeeder::class);
+        $this->call(MessageTableSeeder::class);
     }
 }

--- a/database/seeds/MessageTableSeeder.php
+++ b/database/seeds/MessageTableSeeder.php
@@ -1,0 +1,47 @@
+<?php
+
+use Gladiator\Models\Contest;
+use Gladiator\Models\Message;
+use Gladiator\Repositories\MessageRepository;
+use Illuminate\Database\Seeder;
+
+class MessageTableSeeder extends Seeder
+{
+    protected $repository;
+
+    public function __construct(MessageRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $contests = Contest::all();
+        $defaults = correspondence()->defaults();
+        $types = Message::getTypes();
+        $messages = [];
+
+        foreach ($types as $type) {
+            $messages[$type] = [];
+        }
+
+        foreach ($defaults as $data) {
+            $messages[$data['type']][] = [
+                'subject' => $data['subject'],
+                'body' => $data['body'],
+                'label' => $data['label'],
+            ];
+        }
+
+        foreach ($contests as $contest) {
+            if (! $contest->messages->count()) {
+                $this->repository->createMessagesForContest($contest, $messages);
+            }
+        }
+    }
+}

--- a/resources/views/contests/partials/_form_contest.blade.php
+++ b/resources/views/contests/partials/_form_contest.blade.php
@@ -1,11 +1,11 @@
 <div class="form-item -padded">
     <label class="field-label" for="signup_start_date">Signup Start Date:</label>
-    <input type="date" name="signup_start_date" id="signup_start_date" class="text-field" value="{{ format_date_form_field($contest->waitingRoom, 'signup_start_date') }}"></input>
+    <input type="date" name="signup_start_date" id="signup_start_date" class="text-field" value="{{ isset($contest) ? format_date_form_field($contest->waitingRoom, 'signup_start_date') : '' }}"></input>
 </div>
 
 <div class="form-item -padded">
     <label class="field-label" for="signup_end_date">Signup End Date:</label>
-    <input type="date" name="signup_end_date" id="signup_end_date"  class="text-field" value="{{ format_date_form_field($contest->waitingRoom, 'signup_end_date') }}"></input>
+    <input type="date" name="signup_end_date" id="signup_end_date"  class="text-field" value="{{ isset($contest) ? format_date_form_field($contest->waitingRoom, 'signup_end_date') : '' }}"></input>
 </div>
 
 <div class="form-item -padded">


### PR DESCRIPTION
#### What's this PR do?
This PR adds a seeder for seeding Messages into the database, only for Contests that are missing them.

#### How should this be manually tested?
Try running:

```
artisan db:seed --class="MessageTableSeeder"
```
Then check the database to make sure a contest that previously was missing messages now has them.

#### Any background context you want to provide?
I introduced a bug in #167 when creating a contest from scratch. While the new helper function for form dates is useful, if there is no `$contest` variable, the app would crap out. Did a temporary fix for now, but would like to figure out a better solution. Likely use the helper function in the controller before the `$contest` variable is passed and then go back to just using `{{ ... or old(...) }}` approach.

---
@DoSomething/gladiator 