### PR TITLE
Update appending campaign data

### DIFF
--- a/app/Http/Controllers/CompetitionsController.php
+++ b/app/Http/Controllers/CompetitionsController.php
@@ -47,7 +47,8 @@ class CompetitionsController extends Controller
     public function show(Competition $competition)
     {
         $contest = Contest::find($competition->contest_id);
-        $campaign = $this->manager->getCampaign($contest->campaign_id);
+
+        $contest = $this->manager->appendCampaign($contest);
 
         $users = [];
         $ids = $competition->users->pluck('id')->toArray();
@@ -56,7 +57,7 @@ class CompetitionsController extends Controller
             $users = $this->repository->getAll($ids);
         }
 
-        return view('competitions.show', compact('competition', 'contest', 'users', 'campaign'));
+        return view('competitions.show', compact('competition', 'contest', 'users'));
     }
 
     /**

--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -29,10 +29,7 @@ class ContestsController extends Controller
     {
         $contests = Contest::all();
 
-        // @TODO - Instead of doing this in loop, grab all campaigns at once
-        foreach ($contests as $contest) {
-            $contest->campaign_title = $this->manager->getCampaign($contest->campaign_id)->title;
-        }
+        $contests = $this->manager->appendCampaign($contests);
 
         return view('contests.index', compact('contests'));
     }
@@ -79,9 +76,10 @@ class ContestsController extends Controller
     public function show(Contest $contest)
     {
         $contest = $this->manager->collectContestInfo($contest->id);
-        $campaign = $this->manager->getCampaign($contest->campaign_id);
 
-        return view('contests.show', compact('contest', 'campaign'));
+        $contest = $this->manager->appendCampaign($contest);
+
+        return view('contests.show', compact('contest'));
     }
 
     /**

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -2,11 +2,12 @@
 
 namespace Gladiator\Services;
 
-use Carbon\Carbon;
 use Gladiator\Models\Contest;
-use Gladiator\Repositories\UserRepositoryContract;
-use Gladiator\Services\Northstar\Northstar;
 use Gladiator\Services\Phoenix\Phoenix;
+use Gladiator\Services\Northstar\Northstar;
+use Gladiator\Repositories\UserRepositoryContract;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
 
 class Manager
 {
@@ -169,20 +170,65 @@ class Manager
     }
 
     /**
-     * Get campaign content from Phoenix.
+     * Append Campaign data to the supplied data if applicable.
      *
-     * @TODO - Move the api call into a repository. Also first check cache
-     * for campaign info, if it is there use that instead, if not, grab from
-     * Phoenix.
-     *
-     * @param  string $id  Campaign ID
-     *
-     * @return object $campaign
+     * @param  mixed $data
+     * @return mixed
      */
-    public function getCampaign($id)
+    public function appendCampaign($data)
     {
-        $campaign = $this->phoenix->getCampaign($id);
+        if ($data instanceof Collection) {
+            return $this->appendCampaignToCollection($data);
+        }
 
-        return $campaign;
+        if ($data instanceof Contest) {
+            return $this->appendCampaignToModel($data);
+        }
+
+        return;
+    }
+
+    /**
+     * Append Campaign data to the supplied collection.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $collection
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    protected function appendCampaignToCollection($collection)
+    {
+        $parameters['ids'] = implode(',', $collection->pluck('campaign_id')->all());
+
+        $campaigns = $this->phoenix->getAllCampaigns($parameters);
+        $campaigns = collect($campaigns)->keyBy('id')->all();
+
+        foreach ($collection as $contest) {
+            if (isset($campaigns[$contest->campaign_id])) {
+                $contest->setAttribute('campaign', $campaigns[$contest->campaign_id]);
+            } else {
+                $contest->setAttribute('campaign', null);
+            }
+        }
+
+        return $collection;
+    }
+
+    /**
+     * Append Campaign data to the supplied model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    protected function appendCampaignToModel($model)
+    {
+        $campaign = $this->phoenix->getCampaign((string) $model->campaign_id);
+
+        // @TODO: RestApiClient is a bit wonky with Phoenix calls and error responses.
+        if ($campaign) {
+            $model->setAttribute('campaign', $campaign);
+        } else {
+            $model->setAttribute('campaign', null);
+        }
+
+        return $model;
     }
 }

--- a/app/Services/Northstar/Northstar.php
+++ b/app/Services/Northstar/Northstar.php
@@ -21,10 +21,10 @@ class Northstar extends RestApiClient
     }
 
     /**
-     * Send a GET request to return all users matching a given query from Northstar.
+     * Send a GET request to return all users matching a given query.
      *
      * @param  array $inputs - Filter, search, limit or pagination queries
-     * @return object
+     * @return object|null
      * @see  https://github.com/DoSomething/northstar/blob/dev/documentation/endpoints/users.md#retrieve-all-users
      */
     public function getAllUsers($inputs = [])
@@ -39,7 +39,7 @@ class Northstar extends RestApiClient
      *
      * @param  string  $type
      * @param  string  $id
-     * @return object
+     * @return object|null
      */
     public function getUser($type, $id)
     {
@@ -66,7 +66,7 @@ class Northstar extends RestApiClient
      *
      * @param  string $id
      * @param  string $campaigns
-     * @return bool
+     * @return object|null
      */
     public function getUserSignups($id, $campaigns)
     {

--- a/app/Services/Phoenix/Phoenix.php
+++ b/app/Services/Phoenix/Phoenix.php
@@ -24,21 +24,27 @@ class Phoenix extends RestApiClient
     }
 
     /**
-     * Send a GET request to return a campaign.
+     * Send a GET request to return all campaigns matching a given query.
      *
-     * @param  int $ids
-     * @return object
+     * @param  array  $params
+     * @return object|null
      */
-    public function getCampaign($id)
+    public function getAllCampaigns($params = [])
     {
-        $response = $this->get($this->base_uri . 'campaigns/' . $id);
+        $response = $this->get('campaigns', $params);
 
         return is_null($response) ? null : $response;
     }
 
-    public function getAllCampaigns($params = [])
+    /**
+     * Send a GET request to return a campaign with the specified id.
+     *
+     * @param  string $id
+     * @return object|null
+     */
+    public function getCampaign($id)
     {
-        $response = $this->get('campaigns', $params);
+        $response = $this->get($this->base_uri . 'campaigns/' . $id);
 
         return is_null($response) ? null : $response;
     }

--- a/resources/views/competitions/show.blade.php
+++ b/resources/views/competitions/show.blade.php
@@ -11,7 +11,7 @@
         <div class="wrapper">
             <div class="container__block -half">
                 <ul>
-                    <li><strong>Campaign:</strong> {{ $campaign->title }}</li>
+                    <li><strong>Campaign:</strong> {{ $contest->campaign->title or 'No title available' }}</li>
                     <li><strong>Campaign Run ID:</strong> {{ $contest->campaign_run_id }}</li>
                     <li><strong>Contest ID:</strong> <a href="{{ route('contests.show', $competition->contest_id) }}">{{ $competition->contest_id }}</a></li>
                     <li><strong>Start Date:</strong> {{ $competition->competition_start_date->format('F d, Y') }}</li>

--- a/resources/views/contests/index.blade.php
+++ b/resources/views/contests/index.blade.php
@@ -36,7 +36,7 @@
                             @foreach($contests as $contest)
                                 <tr class="table__row">
                                     <td class="table__cell"><a href="{{ route('contests.show', $contest->id) }}">{{ $contest->id }}</a></td>
-                                    <td class="table__cell"><a href="{{ url(config('services.phoenix.uri') .'/node/' . $contest->campaign_id) }}">{{ $contest->campaign_title }}</a></td>
+                                    <td class="table__cell"><a href="{{ url(config('services.phoenix.uri') .'/node/' . $contest->campaign_id) }}" target="_blank">{{ $contest->campaign->title or 'No title available' }}</a></td>
                                     <td class="table__cell">{{ $contest->campaign_run_id }}</td>
                                     <td class="table__cell">{{ $contest->waitingRoom->signup_end_date->format('F d, Y') }}</td>
                                     <td class="table__cell"><a href="{{ route('waitingrooms.show', $contest->waitingroom->id) }}">{{ $contest->waitingroom->users->count() }}</a></td>

--- a/resources/views/contests/show.blade.php
+++ b/resources/views/contests/show.blade.php
@@ -11,7 +11,7 @@
         <div class="wrapper">
             <div class="container__block -half">
                 <ul>
-                    <li><strong>Campaign:</strong> {{ $campaign->title }}</li>
+                    <li><strong>Campaign:</strong> {{ $contest->campaign->title or 'No title available' }}</li>
                     <li><strong>Campaign Run ID:</strong> {{ $contest->campaign_run_id }}</li>
                 </ul>
             </div>


### PR DESCRIPTION
#### What's this PR do?
This PR updates the approach for how campaign data is appended to instances of `Contest` classes retrieved as a collection or as single model instances. It provides an easy way to send off a contest collection or model to a method on the `Manager` class called `appendCampaign()` that handles adding the full campaign data as a property on the `Contest` object. The property contains the full campaign object, so other data on the campaign is easily accessible :) If there was an issue retrieving the campaign, then the `campaign` property is still set on the contest object, but the value is set to `null`.

#### How should this be manually tested?
Load the site and see if campaign titles are being properly added on the contest's index and show pages, as well as the competition show page.

#### Any background context you want to provide?
This PR provides the first step in setting up the approach for next caching the campaign data for more efficient retrieval on subsequent requests.

#### What are the relevant tickets?
Refs #178

---

@angaither @sbsmith86 @deadlybutter 