### PR TITLE
Proveit link token

### DIFF
--- a/app/Http/Utilities/Email.php
+++ b/app/Http/Utilities/Email.php
@@ -67,16 +67,16 @@ class Email
     {
         // @TODO - set defaults?
         $tokens = [
+            ':campaign_title:'        => $this->contest->campaign->title,
             ':end_date:'              => $this->competition->competition_end_date->format('F d, Y'),
+            ':first_name:'            => $user->first_name,
             ':leaderboard_msg_day:'   => get_day_of_week($this->competition->leaderboard_msg_day),
             ':leaderboard_msg_day-1:' => get_day_of_week($this->competition->leaderboard_msg_day - 1),
-            ':first_name:'            => $user->first_name,
-            ':sender_name:'           => $this->contest->sender_name,
-            ':campaign_title:'        => $this->contest->campaign->title,
-            ':reportback_noun:'       => $this->contest->campaign->reportback_info->noun,
-            ':reportback_verb:'       => $this->contest->campaign->reportback_info->verb,
             ':pro_tip:'               => $this->message->pro_tip,
             ':prove_it_link:'         => url(config('services.phoenix.uri') .'/node/' . $this->contest->campaign_id . '#proveit'),
+            ':reportback_noun:'       => $this->contest->campaign->reportback_info->noun,
+            ':reportback_verb:'       => $this->contest->campaign->reportback_info->verb,
+            ':sender_name:'           => $this->contest->sender_name,
         ];
 
         return $tokens;

--- a/app/Http/Utilities/Email.php
+++ b/app/Http/Utilities/Email.php
@@ -76,6 +76,7 @@ class Email
             ':reportback_noun:'       => $this->contest->campaign->reportback_info->noun,
             ':reportback_verb:'       => $this->contest->campaign->reportback_info->verb,
             ':pro_tip:'               => $this->message->pro_tip,
+            ':prove_it_link:'         => url(config('services.phoenix.uri') .'/node/' . $this->contest->campaign_id . '#proveit'),
         ];
 
         return $tokens;


### PR DESCRIPTION
#### What's this PR do?
Forgot the actual `:prove_it_link:` token in my last [PR]( #186 ) 

But I did add the ability to do markdown like links so now we can do things like:

`[:campaign_title:](:prove_it_link:)`

#### Any background context you want to provide?
More indepth PR on the token handling is [here]( #186 )

#### What are the relevant tickets?
Addresses #153 