### PR TITLE
Locking to older version of Forge until we switch to webpack.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "gulp": "^3.8.8"
   },
   "dependencies": {
-    "@dosomething/forge": "^6.6.2",
+    "@dosomething/forge": "~6.6.0",
     "dosomething-modal": "^0.3.0",
     "laravel-elixir": "^4.0.0"
   }


### PR DESCRIPTION
#### What's this PR do?
This PR locks the version of Forge we use for Gladiator to `6.6.0` and minor patches, because the new versions switch up the build system used and is more specific to the use of Webpack. So until we upgrade the build system we'll stick to a less fancy version so shit don't break!

#### How should this be manually tested?
Does shit break? No? Great. Have a 🍪 

#### What are the relevant tickets?
Fixes #:cookie:
