### PR TITLE
Campaign data caching & general cache improvements

### DIFF
--- a/app/Repositories/CacheCampaignRepository.php
+++ b/app/Repositories/CacheCampaignRepository.php
@@ -2,8 +2,6 @@
 
 namespace Gladiator\Repositories;
 
-use Gladiator\Repositories\CacheStorage;
-
 class CacheCampaignRepository implements RepositoryContract
 {
     use CacheStorage;

--- a/app/Repositories/CacheCampaignRepository.php
+++ b/app/Repositories/CacheCampaignRepository.php
@@ -2,35 +2,19 @@
 
 namespace Gladiator\Repositories;
 
+use Gladiator\Repositories\CacheStorage;
+
 class CacheCampaignRepository implements RepositoryContract
 {
+    use CacheStorage;
+
     public function find($id)
     {
-
-    }
-
-    protected function retrieve()
-    {
-
-    }
-
-    protected function retrieveMany()
-    {
-
+        // stuff
     }
 
     public function getAll(array $ids = [])
     {
-
-    }
-
-    protected function store($key, $value, $minutes = 2)
-    {
-
-    }
-
-    protected function storeMany(array $values, $minutes = 2)
-    {
-
+        // stuff
     }
 }

--- a/app/Repositories/CacheCampaignRepository.php
+++ b/app/Repositories/CacheCampaignRepository.php
@@ -2,17 +2,50 @@
 
 namespace Gladiator\Repositories;
 
+use Gladiator\Services\Phoenix\Phoenix;
+
 class CacheCampaignRepository implements RepositoryContract
 {
     use CacheStorage;
 
+    protected $prefix = 'campaign';
+
+    /**
+     * Create new CacheCampaignRepository instance.
+     */
+    public function __construct()
+    {
+        $this->phoenix = new Phoenix;
+    }
+
+    /**
+     * Find the specified campaign in cache or default to api request.
+     *
+     * @param  string  $id
+     * @return object|null
+     */
     public function find($id)
     {
-        // stuff
+        $key = $this->setPrefix($id, $this->prefix);
+
+        $campaign = $this->retrieve($key);
+
+        if (! $campaign) {
+            // @see https://github.com/DoSomething/gladiator/issues/180
+            $campaign = $this->phoenix->getCampaign($id);
+
+            $this->store($key, $campaign);
+        }
+
+        return $campaign;
     }
 
     public function getAll(array $ids = [])
     {
-        // stuff
+        dd($ids);
     }
 }
+
+// # Notes
+// Make the $minutes a protected property of the trait so it can be overridden
+// if we want to have User cache last 15 min but Campaign cache last 60 min.

--- a/app/Repositories/CacheCampaignRepository.php
+++ b/app/Repositories/CacheCampaignRepository.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Gladiator\Repositories;
+
+class CacheCampaignRepository implements RepositoryContract
+{
+    public function find($id)
+    {
+
+    }
+
+    protected function retrieve()
+    {
+
+    }
+
+    protected function retrieveMany()
+    {
+
+    }
+
+    public function getAll(array $ids = [])
+    {
+
+    }
+
+    protected function store($key, $value, $minutes = 2)
+    {
+
+    }
+
+    protected function storeMany(array $values, $minutes = 2)
+    {
+
+    }
+}

--- a/app/Repositories/CacheCampaignRepository.php
+++ b/app/Repositories/CacheCampaignRepository.php
@@ -49,6 +49,7 @@ class CacheCampaignRepository implements RepositoryContract
      */
     public function getAll(array $ids = [])
     {
+        // @TODO: This is messy and needs another pass to simplify.
         if ($ids) {
             $keys = array_map([$this, 'setPrefix'], $ids);
 
@@ -80,7 +81,3 @@ class CacheCampaignRepository implements RepositoryContract
         return null;
     }
 }
-
-// # Notes
-// Make the $minutes a protected property of the trait so it can be overridden
-// if we want to have User cache last 15 min but Campaign cache last 60 min.

--- a/app/Repositories/CacheStorage.php
+++ b/app/Repositories/CacheStorage.php
@@ -63,6 +63,11 @@ trait CacheStorage
         }
     }
 
+    protected function setPrefix($string, $prefix)
+    {
+        return $prefix . ':' . $string;
+    }
+
     /**
      * Store an item in the cache for a given number of minutes.
      *

--- a/app/Repositories/CacheStorage.php
+++ b/app/Repositories/CacheStorage.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Gladiator\Repositories;
+
+use Illuminate\Support\Facades\Cache;
+
+trait CacheStorage
+{
+    /**
+     * Remove all items from the cache.
+     *
+     * @return void
+     */
+    protected function flush()
+    {
+        Cache::flush();
+    }
+
+    /**
+     * Remove an item from the cache.
+     *
+     * @param  string  $key
+     * @return void
+     * @TODO: Might be best to return a bool like the Laravel class does?
+     */
+    protected function forget($key)
+    {
+        Cache::forget($key);
+    }
+
+    /**
+     * Retrieve an item from the cache by key.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    protected function retrieve($key)
+    {
+        return Cache::get($key);
+    }
+
+    /**
+     * Retrieve multiple items from the cache by key.
+     * Items not found in the cache will have a null value.
+     *
+     * @param  array  $keys
+     * @return array|null
+     */
+    protected function retrieveMany(array $keys)
+    {
+        $retrieved = [];
+
+        $data = Cache::many($keys);
+
+        foreach ($data as $item) {
+            if ($item) {
+                $retrieved[] = $item;
+            }
+        }
+
+        if (count($retrieved)) {
+            return $data;
+        }
+    }
+
+    /**
+     * Store an item in the cache for a given number of minutes.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @param  int     $minutes
+     * @return void
+     */
+    protected function store($key, $value, $minutes = 2)
+    {
+        Cache::put($key, $value, $minutes);
+    }
+
+    /**
+     * Store multiple items in the cache for a given number of minutes.
+     *
+     * @param  array  $values
+     * @param  int  $minutes
+     * @return void
+     */
+    protected function storeMany(array $values, $minutes = 2)
+    {
+        Cache::putMany($values, $minutes);
+    }
+}

--- a/app/Repositories/CacheStorage.php
+++ b/app/Repositories/CacheStorage.php
@@ -111,7 +111,7 @@ trait CacheStorage
      * @param  int     $minutes
      * @return void
      */
-    protected function store($key, $value, $minutes = 2)
+    protected function store($key, $value, $minutes = 15)
     {
         Cache::put($key, $value, $minutes);
     }
@@ -123,7 +123,7 @@ trait CacheStorage
      * @param  int  $minutes
      * @return void
      */
-    protected function storeMany(array $values, $minutes = 2)
+    protected function storeMany(array $values, $minutes = 15)
     {
         Cache::putMany($values, $minutes);
     }

--- a/app/Repositories/CacheStorage.php
+++ b/app/Repositories/CacheStorage.php
@@ -29,6 +29,31 @@ trait CacheStorage
     }
 
     /**
+     * Resolving missing cached items in cache collection.
+     *
+     * @param  array $items
+     * @return array
+     */
+    protected function resolveMissingItems($items)
+    {
+        // @TODO: maybe this should run in the retrieveMany() method?
+        // @TODO: May want to check if calling Class has find() method using method_exists($object, $method_name).
+        // @TODO: Might also be faster to collect the missing items and do a getAll() instead of find() for each individually.
+
+        foreach ($items as $key => $value) {
+            if ($value === false || $value === null) {
+                if (property_exists($this, 'prefix')) {
+                    $id = $this->unsetPrefix($key);
+                }
+
+                $items[$key] = $this->find($id);
+            }
+        }
+
+        return $items;
+    }
+
+    /**
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key
@@ -63,9 +88,19 @@ trait CacheStorage
         }
     }
 
-    protected function setPrefix($string, $prefix)
+    /**
+     * Set a prefix on supplied string used as cache key.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    protected function setPrefix($string)
     {
-        return $prefix . ':' . $string;
+        if (property_exists($this, 'prefix')) {
+            return $this->prefix . ':' . $string;
+        } else {
+            return $string;
+        }
     }
 
     /**
@@ -91,5 +126,20 @@ trait CacheStorage
     protected function storeMany(array $values, $minutes = 2)
     {
         Cache::putMany($values, $minutes);
+    }
+
+    /**
+     * Unset a prefix on supplied string used as cache key.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    protected function unsetPrefix($string)
+    {
+        if (property_exists($this, 'prefix')) {
+            return str_replace('campaign:', '', $string);
+        } else {
+            return $string;
+        }
     }
 }

--- a/app/Repositories/CacheUserRepository.php
+++ b/app/Repositories/CacheUserRepository.php
@@ -79,6 +79,7 @@ class CacheUserRepository implements UserRepositoryContract
 
                 if ($users->count()) {
                     $group = $users->keyBy('id')->all();
+
                     $this->storeMany($group);
                 }
             } else {

--- a/app/Repositories/CacheUserRepository.php
+++ b/app/Repositories/CacheUserRepository.php
@@ -3,7 +3,6 @@
 namespace Gladiator\Repositories;
 
 use Gladiator\Models\User;
-use Gladiator\Repositories\CacheStorage;
 use Illuminate\Support\Facades\Cache;
 
 class CacheUserRepository implements UserRepositoryContract

--- a/app/Repositories/CacheUserRepository.php
+++ b/app/Repositories/CacheUserRepository.php
@@ -70,7 +70,7 @@ class CacheUserRepository implements UserRepositoryContract
      */
     public function getAll(array $ids = [])
     {
-        // @TODO: This is messy and needs another pass.
+        // @TODO: This is messy and needs another pass to simplify.
         if ($ids) {
             $users = $this->retrieveMany($ids);
 

--- a/app/Repositories/CacheUserRepository.php
+++ b/app/Repositories/CacheUserRepository.php
@@ -48,7 +48,7 @@ class CacheUserRepository implements UserRepositoryContract
      */
     public function find($id)
     {
-        $user = Cache::get($id);
+        $user = $this->retrieve($id);
 
         if (! $user) {
             $user = $this->repository->find($id);

--- a/app/Repositories/CacheUserRepository.php
+++ b/app/Repositories/CacheUserRepository.php
@@ -3,10 +3,13 @@
 namespace Gladiator\Repositories;
 
 use Gladiator\Models\User;
+use Gladiator\Repositories\CacheStorage;
 use Illuminate\Support\Facades\Cache;
 
 class CacheUserRepository implements UserRepositoryContract
 {
+    use CacheStorage;
+
     /**
      * UserRepositoryContract instance.
      *
@@ -146,28 +149,6 @@ class CacheUserRepository implements UserRepositoryContract
     }
 
     /**
-     * Remove an item from the cache.
-     *
-     * @param  string  $key
-     * @return void
-     * @TODO: Might be best to return a bool like the Laravel class does?
-     */
-    protected function forget($key)
-    {
-        Cache::forget($key);
-    }
-
-    /**
-     * Remove all items from the cache.
-     *
-     * @return void
-     */
-    protected function flush()
-    {
-        Cache::flush();
-    }
-
-    /**
      * Parse through cached role ids, and update for specified user.
      *
      * @param  string $id  Northstar ID
@@ -214,66 +195,5 @@ class CacheUserRepository implements UserRepositoryContract
         }
 
         return $users;
-    }
-
-    /**
-     * Retrieve an item from the cache by key.
-     *
-     * @param  string  $key
-     * @return mixed
-     */
-    protected function retrieve($key)
-    {
-        return Cache::get($key);
-    }
-
-    /**
-     * Retrieve multiple items from the cache by key.
-     *
-     * Items not found in the cache will have a null value.
-     *
-     * @param  array  $keys
-     * @return array|null
-     */
-    protected function retrieveMany(array $keys)
-    {
-        $retrieved = [];
-
-        $data = Cache::many($keys);
-
-        foreach ($data as $item) {
-            if ($item) {
-                $retrieved[] = $item;
-            }
-        }
-
-        if (count($retrieved)) {
-            return $data;
-        }
-    }
-
-    /**
-     * Store an item in the cache for a given number of minutes.
-     *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @param  int     $minutes
-     * @return void
-     */
-    protected function store($key, $value, $minutes = 15)
-    {
-        Cache::put($key, $value, $minutes);
-    }
-
-    /**
-     * Store multiple items in the cache for a given number of minutes.
-     *
-     * @param  array  $values
-     * @param  int  $minutes
-     * @return void
-     */
-    protected function storeMany(array $values, $minutes = 15)
-    {
-        Cache::putMany($values, $minutes);
     }
 }

--- a/app/Repositories/RepositoryContract.php
+++ b/app/Repositories/RepositoryContract.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gladiator\Repositories;
+
+interface RepositoryContract
+{
+    /**
+     * Find the specified resource in the repository.
+     *
+     * @param  string  $id
+     * @return object
+     */
+    public function find($id);
+
+    /**
+     * Get collection of all resources or set of resources by ids.
+     *
+     * @param  array  $ids
+     * @return \Illuminate\Support\Collection
+     */
+    public function getAll(array $ids = []);
+}

--- a/app/Repositories/UserRepositoryContract.php
+++ b/app/Repositories/UserRepositoryContract.php
@@ -2,7 +2,7 @@
 
 namespace Gladiator\Repositories;
 
-interface UserRepositoryContract
+interface UserRepositoryContract extends RepositoryContract
 {
     /**
      * Create a new user.
@@ -18,7 +18,7 @@ interface UserRepositoryContract
      * @param  string  $id  Northstar ID
      * @return object
      */
-    public function find($id);
+    // public function find($id);
 
     /**
      * Get collection of all users or set of users by ids.
@@ -26,7 +26,7 @@ interface UserRepositoryContract
      * @param  array $ids Northstar IDs
      * @return \Illuminate\Support\Collection
      */
-    public function getAll(array $ids = []);
+    // public function getAll(array $ids = []);
 
     /**
      * Get collection of users by the specified role.

--- a/app/Repositories/UserRepositoryContract.php
+++ b/app/Repositories/UserRepositoryContract.php
@@ -13,22 +13,6 @@ interface UserRepositoryContract extends RepositoryContract
     public function create($account);
 
     /**
-     * Find the specified resource in the database.
-     *
-     * @param  string  $id  Northstar ID
-     * @return object
-     */
-    // public function find($id);
-
-    /**
-     * Get collection of all users or set of users by ids.
-     *
-     * @param  array $ids Northstar IDs
-     * @return \Illuminate\Support\Collection
-     */
-    // public function getAll(array $ids = []);
-
-    /**
      * Get collection of users by the specified role.
      *
      * @param  string $role

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -292,7 +292,6 @@ class Manager
 
         // First check the campaign cache repository...
 
-
         $parameters['ids'] = implode(',', $campaignIds);
 
         $campaigns = $this->phoenix->getAllCampaigns($parameters);

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -4,7 +4,6 @@ namespace Gladiator\Services;
 
 use Carbon\Carbon;
 use Gladiator\Models\Contest;
-use Gladiator\Services\Phoenix\Phoenix;
 use Gladiator\Services\Northstar\Northstar;
 use Gladiator\Repositories\CacheCampaignRepository;
 use Gladiator\Repositories\UserRepositoryContract;
@@ -34,13 +33,6 @@ class Manager
     protected $northstar;
 
     /**
-     * Phoenix instance.
-     *
-     * @var \Gladiator\Services\Phoenix\Phoenix
-     */
-    protected $phoenix;
-
-    /**
      * Create new Registrar instance.
      *
      * @param  $userRepository
@@ -51,7 +43,6 @@ class Manager
         $this->campaignRepository = $campaignRepository;
         $this->userRepository = $userRepository;
         $this->northstar = new Northstar;
-        $this->phoenix = new Phoenix;
     }
 
     /**

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -291,22 +291,19 @@ class Manager
     {
         $campaignIds = $collection->pluck('campaign_id')->all();
 
-        return $this->campaignRepository->getAll($campaignIds);
+        $campaigns = $this->campaignRepository->getAll($campaignIds);
 
-        // $parameters['ids'] = implode(',', $campaignIds);
+        $campaigns = $campaigns->keyBy('id')->all();
 
-        // $campaigns = $this->phoenix->getAllCampaigns($parameters);
-        // $campaigns = collect($campaigns)->keyBy('id')->all();
+        foreach ($collection as $contest) {
+            if (isset($campaigns[$contest->campaign_id])) {
+                $contest->setAttribute('campaign', $campaigns[$contest->campaign_id]);
+            } else {
+                $contest->setAttribute('campaign', null);
+            }
+        }
 
-        // foreach ($collection as $contest) {
-        //     if (isset($campaigns[$contest->campaign_id])) {
-        //         $contest->setAttribute('campaign', $campaigns[$contest->campaign_id]);
-        //     } else {
-        //         $contest->setAttribute('campaign', null);
-        //     }
-        // }
-
-        // return $collection;
+        return $collection;
     }
 
     /**

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -43,7 +43,8 @@ class Manager
     /**
      * Create new Registrar instance.
      *
-     * @param Northstar $northstar
+     * @param  $userRepository
+     * @param  $campaignRepository
      */
     public function __construct(UserRepositoryContract $userRepository, CacheCampaignRepository $campaignRepository)
     {
@@ -290,22 +291,22 @@ class Manager
     {
         $campaignIds = $collection->pluck('campaign_id')->all();
 
-        // First check the campaign cache repository...
+        return $this->campaignRepository->getAll($campaignIds);
 
-        $parameters['ids'] = implode(',', $campaignIds);
+        // $parameters['ids'] = implode(',', $campaignIds);
 
-        $campaigns = $this->phoenix->getAllCampaigns($parameters);
-        $campaigns = collect($campaigns)->keyBy('id')->all();
+        // $campaigns = $this->phoenix->getAllCampaigns($parameters);
+        // $campaigns = collect($campaigns)->keyBy('id')->all();
 
-        foreach ($collection as $contest) {
-            if (isset($campaigns[$contest->campaign_id])) {
-                $contest->setAttribute('campaign', $campaigns[$contest->campaign_id]);
-            } else {
-                $contest->setAttribute('campaign', null);
-            }
-        }
+        // foreach ($collection as $contest) {
+        //     if (isset($campaigns[$contest->campaign_id])) {
+        //         $contest->setAttribute('campaign', $campaigns[$contest->campaign_id]);
+        //     } else {
+        //         $contest->setAttribute('campaign', null);
+        //     }
+        // }
 
-        return $collection;
+        // return $collection;
     }
 
     /**
@@ -316,7 +317,9 @@ class Manager
      */
     protected function appendCampaignToModel($model)
     {
-        $campaign = $this->phoenix->getCampaign((string) $model->campaign_id);
+        $campaignId = (string) $model->campaign_id;
+
+        $campaign = $this->campaignRepository->find($campaignId);
 
         // @TODO: RestApiClient is a bit wonky with Phoenix calls and error responses.
         if ($campaign) {

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -2,21 +2,29 @@
 
 namespace Gladiator\Services;
 
+use Carbon\Carbon;
 use Gladiator\Models\Contest;
 use Gladiator\Services\Phoenix\Phoenix;
 use Gladiator\Services\Northstar\Northstar;
+use Gladiator\Repositories\CacheCampaignRepository;
 use Gladiator\Repositories\UserRepositoryContract;
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Collection;
 
 class Manager
 {
     /**
+     * CacheCampaignRepository instance.
+     *
+     * @var \Gladiator\Repositories\CacheCampaignRepository
+     */
+    protected $campaignRepository;
+
+    /**
      * UserRepositoryContract instance.
      *
      * @var \Gladiator\Repositories\UserRepositoryContract
      */
-    protected $repository;
+    protected $userRepository;
 
     /**
      * Northstar instance.
@@ -37,9 +45,10 @@ class Manager
      *
      * @param Northstar $northstar
      */
-    public function __construct(UserRepositoryContract $repository)
+    public function __construct(UserRepositoryContract $userRepository, CacheCampaignRepository $campaignRepository)
     {
-        $this->repository = $repository;
+        $this->campaignRepository = $campaignRepository;
+        $this->userRepository = $userRepository;
         $this->northstar = new Northstar;
         $this->phoenix = new Phoenix;
     }
@@ -279,7 +288,12 @@ class Manager
      */
     protected function appendCampaignToCollection($collection)
     {
-        $parameters['ids'] = implode(',', $collection->pluck('campaign_id')->all());
+        $campaignIds = $collection->pluck('campaign_id')->all();
+
+        // First check the campaign cache repository...
+
+
+        $parameters['ids'] = implode(',', $campaignIds);
 
         $campaigns = $this->phoenix->getAllCampaigns($parameters);
         $campaigns = collect($campaigns)->keyBy('id')->all();

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -57,7 +57,7 @@ class Manager
         $data = [];
         $users = $model->users;
 
-        $users = $this->repository->getAll($users->pluck('id')->all());
+        $users = $this->userRepository->getAll($users->pluck('id')->all());
         $users = $users->keyBy('id')->all();
 
         $headers = ['northstar_id', 'first_name', 'last_name', 'email', 'cell'];
@@ -107,7 +107,7 @@ class Manager
         $users = $competition->users;
 
         // Get all users in bulk
-        $users = $this->repository->getAll($users->pluck('id')->all());
+        $users = $this->userRepository->getAll($users->pluck('id')->all());
         $users = $users->keyBy('id')->all();
 
         foreach ($users as $user) {

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -3,6 +3,7 @@
 use Faker\Generator;
 use Gladiator\Models\User;
 use Gladiator\Models\Contest;
+use Gladiator\Services\Phoenix\Phoenix;
 
 /*
 |--------------------------------------------------------------------------
@@ -25,9 +26,16 @@ $factory->define(User::class, function (Generator $faker) {
 
 // Contest Factory.
 $factory->define(Contest::class, function (Generator $faker) {
+
+    $phoenix = new Phoenix;
+
+    $campaignIds = ['1247', '1663', '1581', '1593', '1467', '1334', '362', '46', '1650', '1560', '1222', '1667', '74', '1198', '886', '1492', '850', '1503', '1376', '1665', '955', '31'];
+
+    $campaign = $phoenix->getCampaign($campaignIds[array_rand($campaignIds)]);
+
     return [
-        'campaign_id' => $faker->numberBetween(10, 300),
-        'campaign_run_id' => $faker->numberBetween(1000, 3000),
+        'campaign_id' => $campaign->id,
+        'campaign_run_id' => $campaign->campaign_runs->current->en->id,
         'sender_email' => $faker->safeEmail(),
         'sender_name' => $faker->name(),
     ];


### PR DESCRIPTION
#### What's this PR do?
This PR expands on the work done in #182 to now also cache the campaign data in Redis and prefix it with `campaign:` just in case to avoid any collisions with future caching of data. The update also refactors the caching system a bit to use a `CacheStorage` trait for all the general caching methods that not _both_ the `CacheCampaignRepository` AND `CacheUserRepository` both use. DRY that shiz up! Both classes `use` the new trait to expand their functionality. 

It also breaks out a new general `RepositoryContract` for all Repository related classes, that other contracts can extend and all Repository related classed must implement.

Lastly, this PR also updates the `Contest` seeding to use real, actual campaign from DS staging. 🎉  The random numbers we were using to temporarily fill in those database fields were starting to cause too many issues with building out features, and had to constantly manually edit the ids to real campaign ids in the database. No more of that sillyness.

#### How should this be manually tested?
The usual, pul down, `dump-autoload`, do a full `migrate:refresh` and `db:seed` and then peruse the contests? Is stuff broken? Are you seeing actual campaign titles. You can also jump into Redis on Homestead and check if stuff is being cached using:

```
redis-cli
```
```
keys *
```

If you are seeing keys that look like `laravel:campaign:955` (the id number will vary) then it's working!

#### Any background context you want to provide?
what else?

#### What are the relevant tickets?
Fixes #178

---
@DoSomething/gladiator 