### PR TITLE
Turn new lines into <br> tags

### DIFF
--- a/app/Http/Utilities/Email.php
+++ b/app/Http/Utilities/Email.php
@@ -98,6 +98,7 @@ class Email
         foreach ($parsableProperties as $prop) {
             $processedMessage->$prop = $this->replaceTokens($tokens, $message->$prop);
             $processedMessage->$prop = $this->parseLinks($processedMessage->$prop);
+            $processedMessage->$prop = nl2br($processedMessage->$prop);
         }
 
         return $processedMessage;


### PR DESCRIPTION
#### What's this PR do?

As a part of the message processing we turn newlines into <br> tags. Before, admins would have to add `<br>` to the message body in order to get the HTML email to be formatted properly. This allows admins to just use normal returns and we handle the formatting on the backend. 

#### How should this be manually tested?

Add some newlines to a message and send yourself a test email. The new lines should be reflected in email body.

#### What are the relevant tickets?
Fixes #185 
