### PR TITLE
Add optional logging to API requests.

### DIFF
--- a/app/Services/RestApiClient.php
+++ b/app/Services/RestApiClient.php
@@ -125,6 +125,10 @@ class RestApiClient
     protected function send($method, $path, $options = [])
     {
         try {
+            if(env('LOG_API_REQUESTS')) {
+                logger('made an API request', compact('method', 'path', 'options'));
+            }
+            
             return $this->client->request($method, $path, $options);
         } catch (RequestException $error) {
             $response = $this->getJson($error->getResponse());

--- a/app/Services/RestApiClient.php
+++ b/app/Services/RestApiClient.php
@@ -125,10 +125,10 @@ class RestApiClient
     protected function send($method, $path, $options = [])
     {
         try {
-            if(env('LOG_API_REQUESTS')) {
+            if (env('LOG_API_REQUESTS')) {
                 logger('made an API request', compact('method', 'path', 'options'));
             }
-            
+
             return $this->client->request($method, $path, $options);
         } catch (RequestException $error) {
             $response = $this->getJson($error->getResponse());


### PR DESCRIPTION
#### What's this PR do?
Adds optional logging to `RestApiClient`'s "send" method.

#### How should this be manually tested?
Set the `LOG_API_REQUESTS` environment variable to be true, and like, check the logs!

#### Any background context you want to provide?
:cactus: 

#### What are the relevant tickets?
:books: 
