### PR TITLE
Raises the Guzzle timeout

### DIFF
--- a/app/Services/RestApiClient.php
+++ b/app/Services/RestApiClient.php
@@ -27,7 +27,7 @@ class RestApiClient
 
         $client = new Client([
             'base_uri' => $base_uri,
-            'timeout' => 2.0,
+            'timeout' => 20.0,
             'headers' => $headers,
         ]);
 


### PR DESCRIPTION
#### What's this PR do?
Increases guzzle timeout to 20 seconds

#### How should this be manually tested?
Does the site still work?
Does prod exports / leaderboards work?

#### Any background context you want to provide?
Exports were not working on prod, most of the time. Sometimes they did work, sometimes not.
The problem never appeared to be outside of Gladiator.
After an intense day of logging, I was able to confirm the requests being made were correct.  Something was wrong with the response var. I then logged the error, finally caught it, and it complained about a timeout. 

```
[2016-04-14 20:38:53] production.DEBUG: errorrr {"error":"[object] (GuzzleHttp\\Exception\\ConnectException(code: 0): cURL error 28: Operation timed out after 2001 milliseconds with 0 bytes received (see http://curl.haxx.se/libcurl/c/libcurl-errors.html) at /var/www/gladiator/releases/20160414185536/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php:186)"} 
[2016-04-14 20:38:53] production.ERROR: exception 'Symfony\Component\Debug\Exception\FatalErrorException' with message 'Call to a member function getBody() on a non-object' in /var/www/gladiator/releases/20160414185536/app/Services/RestApiClient.php:103
Stack trace:
#0 {main}  
```

A timeout of 2 seconds would probably die with the amount of users were asking for at once, and explains both the randomness & the prod only ness.

I've changed the code live on prod to prove this theory, and have yet to encounter a failed export or leaderboard.

#### What are the relevant tickets?
Fixes MY BRAIN.
Fixes #223 