### PR TITLE
Updates to fix showing User activity on single user show page.

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -2,12 +2,11 @@
 
 namespace Gladiator\Http\Controllers;
 
-use Gladiator\Http\Requests\UserRequest;
-use Gladiator\Models\Competition;
 use Gladiator\Models\User;
-use Gladiator\Repositories\UserRepositoryContract;
 use Gladiator\Services\Manager;
 use Gladiator\Services\Registrar;
+use Gladiator\Http\Requests\UserRequest;
+use Gladiator\Repositories\UserRepositoryContract;
 
 class UsersController extends Controller
 {

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -153,18 +153,6 @@ class Manager
         $signup = $this->northstar->getUserSignups($parameters);
 
         return array_shift($signup);
-
-        // if (is_array($signup)) {
-        //     $signup = reset($signup);
-        // }
-
-        // if ($signup && $signup->reportback) {
-        //     dd('here');
-        //     return $this->formatReportback($signup->reportback);
-        // }
-
-        // // If the user has no activity for this competition or waiting room.
-        // return null;
     }
 
     /**

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -65,7 +65,7 @@ class Manager
             ];
 
             if (isset($user->reportback)) {
-                $details[] = env('PHOENIX_URI') . '/admin/reportback/' . $user->reportback->id;
+                $details[] = reportback_admin_url($user->reportback->id);
                 $details[] = $user->reportback->quantity;
                 $details[] = $user->reportback->reportback_items->count_by_status['promoted'];
                 $details[] = $user->reportback->reportback_items->count_by_status['approved'];
@@ -134,41 +134,44 @@ class Manager
             return $users;
         }
 
-        return $this->appendReportback($users, $model);
+        return $this->appendReportback($users, $this->getCampaignParameters($model));
     }
 
     /**
-     * Get a user's signup/reportback activity for a
-     * competition or waiting room.
+     * Get reportbacks for a user & supplied parameters.
      *
-     * @param  string $id  User ID
-     * @param  \Gladiator\Models\Competition|WaitingRoom $model
-     * @return object $reportback
+     * @param  string  $id
+     * @param  array  $parameters
+     * @return object
      */
-    public function getActivityForUser($id, $model)
+    public function getActivityForUser($id, $parameters = [])
     {
-        $campaign = $model->contest->campaign_id;
-        $campaign_run = $model->contest->campaign_run_id;
+        $parameters['users'] = $id;
+        $parameters['count'] = 25;
 
-        $signup = $this->northstar->getUserSignups($id, $campaign, $campaign_run);
+        // @TODO: Investigat NS proxy; passing a bad ID results in general index of signups response.
+        $signup = $this->northstar->getUserSignups($parameters);
 
-        if (is_array($signup)) {
-            $signup = reset($signup);
-        }
+        return array_shift($signup);
 
-        if ($signup && $signup->reportback) {
-            return $this->formatReportback($signup->reportback);
-        }
+        // if (is_array($signup)) {
+        //     $signup = reset($signup);
+        // }
 
-        // If the user has no activity for this competition or waiting room.
-        return null;
+        // if ($signup && $signup->reportback) {
+        //     dd('here');
+        //     return $this->formatReportback($signup->reportback);
+        // }
+
+        // // If the user has no activity for this competition or waiting room.
+        // return null;
     }
 
     /**
-     * Get reportbacks for many users & a given competition.
+     * Get reportbacks for many users & supplied parameters.
      *
      * @param  array  $ids
-     * @param  \Gladiator\Models\Competition  $competition
+     * @param  array  $parameters
      * @param  int  $batchSize
      * @return \Illuminate\Support\Collection $signups
      */
@@ -190,6 +193,31 @@ class Manager
         }
 
         return collect($signups);
+    }
+
+    /**
+     * Get the campaign information as parameters for API requests.
+     * 
+     * @param  \Gladiator\Models\Contest|Competition  $model
+     * @return array
+     */
+    public function getCampaignParameters($model)
+    {
+        $parameters = [];
+
+        if ($model instanceof \Gladiator\Models\Contest) {
+            $parameters['campaigns'] = $model->campaign_id;
+            $parameters['runs'] = $model->campaign_run_id;
+        }
+
+        if ($model instanceof \Gladiator\Models\Competition) {
+            if ($model->contest) {
+                $parameters['campaigns'] = $model->contest->campaign_id;
+                $parameters['runs'] = $model->contest->campaign_run_id;
+            }    
+        }
+
+        return $parameters;
     }
 
     /**
@@ -215,24 +243,21 @@ class Manager
      * Append Reportback data to the supplied data if applicable.
      *
      * @param  mixed  $data
-     * @param  \Gladiator\Models\Competition  $model
+     * @param  array  $parameters
      * @return mixed
      */
-    public function appendReportback($data, $model)
+    public function appendReportback($data, $parameters)
     {
-        $parameters = [];
-
-        if ($model->contest) {
-            $parameters['campaigns'] = $model->contest->campaign_id;
-            $parameters['runs'] = $model->contest->campaign_run_id;
-        }
-
         if ($data instanceof \Illuminate\Support\Collection) {
             return $this->appendReportbackToCollection($data, $parameters);
         }
 
+        if ($data instanceof \Gladiator\Models\Competition) {
+            return $this->appendReportbackToModel($data, $parameters);
+        }
+
         if ($data instanceof \stdClass) {
-            return $this->appendReportbackToObject($data, $parameters);
+            return $this->appendReportbackToUserObject($data, $parameters);
         }
 
         return null;
@@ -311,18 +336,40 @@ class Manager
         return $collection;
     }
 
+    protected function appendReportbackToModel($model, $parameters)
+    {
+        $userId = $parameters['users'];
+        unset($parameters['users']);
+        // @TODO: potential refactor; not a fan of the above, but leaving for now.
+
+        $activity = $this->getActivityForUser($userId, $parameters);
+
+        if ($activity) {
+            $model->setAttribute('reportback', $activity->reportback);
+        } else {
+            $model->setAttribute('reportback', null);
+        }
+
+        return $model;
+    }
+
     /**
      * Append Reportback data to the supplied user object.
      *
-     * @param  object  $object
+     * @param  object  $user
      * @param  array  $parameters
      * @return object
      */
-    protected function appendReportbackToObject($object, $parameters)
+    protected function appendReportbackToUserObject($user, $parameters)
     {
-        // @TODO: not used at the moment, but will be @_@
-        // grab reportback and append to user object
+        $activity = $this->getActivityForUser($user->id, $parameters);
 
-        return null;
+        if ($activity) {
+            $user->reportback = $activity->reportback;
+        } else {
+            $user->reportback = null;
+        }
+
+        return $user;
     }
 }

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -197,7 +197,7 @@ class Manager
 
     /**
      * Get the campaign information as parameters for API requests.
-     * 
+     *
      * @param  \Gladiator\Models\Contest|Competition  $model
      * @return array
      */
@@ -214,7 +214,7 @@ class Manager
             if ($model->contest) {
                 $parameters['campaigns'] = $model->contest->campaign_id;
                 $parameters['runs'] = $model->contest->campaign_run_id;
-            }    
+            }
         }
 
         return $parameters;

--- a/app/Services/Northstar/Northstar.php
+++ b/app/Services/Northstar/Northstar.php
@@ -61,6 +61,12 @@ class Northstar extends RestApiClient
         return $response ? true : false;
     }
 
+    /**
+     * Send a GET request to return all signups for the supplied collection of users.
+     *
+     * @param  array  $inputs
+     * @return object|null
+     */
     public function getAllUserSignups($inputs = [])
     {
         $response = $this->get('signups', $inputs);
@@ -71,19 +77,12 @@ class Northstar extends RestApiClient
     /*
      * Send a GET request to return a user's signups.
      *
-     * @param  string $ids
-     * @param  string $campaigns
-     * @param  int|array $runs
+     * @param  array  $inputs
      * @return object|null
      */
-    public function getUserSignups($ids, $campaigns, $runs = '', $count = 25)
+    public function getUserSignups($inputs = [])
     {
-        $response = $this->get('signups', [
-            'users' => $ids,
-            'campaigns' => $campaigns,
-            'runs' => $runs,
-            'count' => $count,
-        ]);
+        $response = $this->get('signups', $inputs);
 
         return is_null($response) ? null : $response;
     }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -73,6 +73,17 @@ function format_date_form_field($model, $field, $defaut = 'MM/DD/YYYY')
 }
 
 /**
+ * Formate a timestamp using Carbon for display in a view.
+ *
+ * @param  string  $timestamp
+ * @return /Carbon/Carbon
+ */
+function format_timestamp_for_display($timestamp)
+{
+    return (new Carbon($timestamp))->format('Y-m-d');
+}
+
+/**
  * Check if the waiting room signup period ended.
  *
  * @param  date  $signupDate
@@ -110,4 +121,15 @@ function match_email_domain($email, $domain = 'dosomething.org')
 function get_day_of_week($day)
 {
     return jddayofweek($day, 1);
+}
+
+/**
+ * Generate Phoenix admin URL for specified reportback.
+ *
+ * @param  string $id
+ * @return string
+ */
+function reportback_admin_url($id)
+{
+    return env('PHOENIX_URI') . '/admin/reportback/' . $id;
 }

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,3 +1,5 @@
+{{-- dd($activities) --}}
+
 @extends('layouts.master')
 
 @section('main_content')
@@ -38,12 +40,11 @@
                             <th class="table__cell">Items</th>
                             <th class="table__cell">Quantity</th>
                             <th class="table__cell">Updated At</th>
-                            <th class="table__cell">Flagged</th>
                             <th class="table__cell">Remove from Competition</th>
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach ($competitions as $competition)
+                        @foreach ($activities as $competition)
                             <tr class="table__row">
                                 <td class="table__cell">
                                     <a href="{{ route('contests.show', $competition->contest->id) }}">
@@ -55,20 +56,20 @@
                                         {{ $competition->id }}
                                     </a>
                                 </td>
-                                <td class="table__cell">
-                                    @if ($competition->reportback)
-                                        <a href="{{ $competition->reportback->admin_url }}">
-                                            {{ $competition->reportback->id }}
-                                        </a>
-                                    @else
-                                        N/A
-                                    @endif
-                                </td>
-                                <td class="table__cell">{{ $competition->reportback->reportback_items->total or 'N/A'}}</td>
-                                <td class="table__cell">{{ $competition->reportback->quantity or 'N/A'}}</td>
-                                <td class="table__cell">{{ $competition->reportback->updated_at or 'N/A'}}</td>
-                                <td class="table__cell">{{ $competition->reportback->flagged or 'N/A' }}</td>
-                                <td class="table__cell"><a href="{{ route('competitions.users.destroy', ['user' => $user->id, 'competition' =>$competition->id]) }}" class="button -danger">Remove</a></td>
+
+                                @if ($competition->reportback)
+                                    <td class="table__cell"><a href="{{ reportback_admin_url($competition->reportback->id) }}">{{ $competition->reportback->id }}</a></td>
+                                    <td class="table__cell">{{ $competition->reportback->reportback_items->total }}</td>
+                                    <td class="table__cell">{{ $competition->reportback->quantity }}</td>
+                                    <td class="table__cell">{{ format_timestamp_for_display($competition->reportback->updated_at) }}</td>
+                                @else
+                                    <td class="table__cell">N/A</td>
+                                    <td class="table__cell">N/A</td>
+                                    <td class="table__cell">N/A</td>
+                                    <td class="table__cell">N/A</td>
+                                @endif
+
+                                <td class="table__cell"><a href="{{ route('competitions.users.destroy', ['user' => $user->id, 'competition' =>$competition->id]) }}" class="button -secondary -danger">Remove</a></td>
                             </tr>
                         @endforeach
                     </tbody>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,5 +1,3 @@
-{{-- dd($activities) --}}
-
 @extends('layouts.master')
 
 @section('main_content')


### PR DESCRIPTION
#### What's this PR do?
This PR fixes an error with a missing function call that was introduced after #224 was merged. This cleans up and fixes that issue using a similar approach as some of the other methods in the `Manager` class. It also adds a few helpful helper functions.

#### How should this be manually tested?
Load a competition with users, click on a user to view their individual page, and see if their user activity is displayed for the competition with Reportbacks (if any), etc.

#### What are the relevant tickets?
Fixes #227

---
@DoSomething/gladiator 
