### PR TITLE
Removing the pro tip text from the default emails

### DIFF
--- a/app/Http/Utilities/Correspondence.php
+++ b/app/Http/Utilities/Correspondence.php
@@ -71,7 +71,7 @@ class Correspondence
             'key' => '1',
             'label' => 'Leaderboard update',
             'subject' => '1st :campaign_title: Leaderboard Update',
-            'body' => "Hello Competitors,\n\rHere is your first official :campaign_title: competition update! The competition ends on :end_date:. Finish in the top 3 in :reportback_noun: :reportback_verb: and win:\n\r- 1st place: ­ $100 amex card\r\n- 2nd place: ­ $50 amex card\r\n- 3rd place: ­ $25 amex card\n\rTwo more weeks to increase your number of :reportback_noun: :reportback_verb: to move up the leaderboard! [Upload your photos here](:prove_it_link:).\n\rPro tip ­- :pro_tip:\n\rNext :reportback_noun: will be due :leaderboard_msg_day-1: before 10pm est.\n\rHere is the leaderboard! Shoutouts to the top 3 below:",
+            'body' => "Hello Competitors,\n\rHere is your first official :campaign_title: competition update! The competition ends on :end_date:. Finish in the top 3 in :reportback_noun: :reportback_verb: and win:\n\r- 1st place: ­ $100 amex card\r\n- 2nd place: ­ $50 amex card\r\n- 3rd place: ­ $25 amex card\n\rTwo more weeks to increase your number of :reportback_noun: :reportback_verb: to move up the leaderboard! [Upload your photos here](:prove_it_link:).\n\r:pro_tip:\n\rNext :reportback_noun: will be due :leaderboard_msg_day-1: before 10pm est.\n\rHere is the leaderboard! Shoutouts to the top 3 below:",
             'pro_tip' => null,
         ],
         [
@@ -79,7 +79,7 @@ class Correspondence
             'key' => '2',
             'label' => 'Leaderboard update 2',
             'subject' => 'Leaderboard update #2 for the :campaign_title: competition!',
-            'body' => "Hello, competitors-- \n\r1 more week! This :campaign_title: competition ends on :end_date:, so it’s time to make your mark.\n\rPro tip - :pro_tip:\n\rA final photo with your :reportback_noun: will be due :leaderboard_msg_day-1: before 10pm EST. [Upload yours here](:prove_it_link:).\n\rHere is the leaderboard! Shoutouts to the top 3 below:\n\r1 more week to make your mark and climb up the leaderboard!",
+            'body' => "Hello, competitors-- \n\r1 more week! This :campaign_title: competition ends on :end_date:, so it’s time to make your mark.\n\r:pro_tip:\n\rA final photo with your :reportback_noun: will be due :leaderboard_msg_day-1: before 10pm EST. [Upload yours here](:prove_it_link:).\n\rHere is the leaderboard! Shoutouts to the top 3 below:\n\r1 more week to make your mark and climb up the leaderboard!",
             'pro_tip' => null,
         ],
         [


### PR DESCRIPTION
#### What's this PR do?
What the title says

#### How should this be manually tested?
Does it say pro tip in the email even if there isnt a super pro tip?

#### Any background context you want to provide?
See comments in issue below

#### What are the relevant tickets?
Fixes #217 