### PR TITLE
Emails with leaderboard

### DIFF
--- a/app/Http/Controllers/MessagesController.php
+++ b/app/Http/Controllers/MessagesController.php
@@ -9,7 +9,6 @@ use Gladiator\Models\Message;
 use Gladiator\Events\QueueMessageRequest;
 use Gladiator\Repositories\MessageRepository;
 use Gladiator\Repositories\UserRepositoryContract;
-use Gladiator\Http\Utilities\Email;
 use Gladiator\Services\Manager;
 
 class MessagesController extends Controller

--- a/app/Http/Controllers/MessagesController.php
+++ b/app/Http/Controllers/MessagesController.php
@@ -104,7 +104,7 @@ class MessagesController extends Controller
                 'email' => $contest->sender_email,
             ];
         } else {
-            $users = $this->manager->getModelUsers($competition);
+            $users = $this->manager->getModelUsers($competition, true);
         }
 
         $resources = [

--- a/app/Http/Utilities/Correspondence.php
+++ b/app/Http/Utilities/Correspondence.php
@@ -89,7 +89,7 @@ class Correspondence
             'subject' => 'Leaderboard update #2 for the :campaign_title: competition!',
             'body' => "Hello, competitors-- \n\r1 more week! This :campaign_title: competition ends on :end_date:, so it’s time to make your mark.\n\r:pro_tip:\n\rA final photo with your :reportback_noun: will be due :leaderboard_msg_day-1: before 10pm EST. [Upload yours here](:prove_it_link:).\n\rHere is the leaderboard! Shoutouts to the top 3 below:\n\r1 more week to make your mark and climb up the leaderboard!",
             'pro_tip' => null,
-            'signoff' => "1 more week to make your mark and climb up the leaderboard!",
+            'signoff' => '1 more week to make your mark and climb up the leaderboard!',
         ],
         [
             'type' => 'leaderboard',

--- a/app/Http/Utilities/Correspondence.php
+++ b/app/Http/Utilities/Correspondence.php
@@ -17,6 +17,7 @@ class Correspondence
             'subject' => 'Welcome, :first_name:!',
             'body' => "Woohoo, so glad you signed up for my :campaign_title: competition, :first_name:! Feel free to get a head start on the competition! Again, winners will be selected based on the greatest number of :reportback_noun: :reportback_verb:.\n\rI’ll be in touch with more info in the next few days. Excited to watch you climb the leaderboard and crush the competition!\n\r:sender_name:",
             'pro_tip' => null,
+            'signoff' => null,
         ],
         [
             'type' => 'info',
@@ -25,6 +26,7 @@ class Correspondence
             'subject' => ':first_name:! Here’s more :campaign_title: competition info',
             'body' => "Just wanted to send along some more info about the :campaign_title: competition you signed up for! The rules are simple:\n\r1. The more :reportback_noun: :reportback_verb:, the higher you move up the leaderboard.\n\r2. To be considered, go to the [Prove It](:prove_it_link:) section of the campaign and upload a photo that clearly shows you and all :reportback_noun: :reportback_verb:. Submissions are due each :leaderboard_msg_day-1: night throughout the campaign.\n\rThe competitor with the most :reportback_noun: :reportback_verb: by the competition deadline of :end_date:, wins $100 on an Amex gift card. 2nd - $50, 3rd - $25.\n\rYour first update is due on :leaderboard_msg_day-1: before 10 PM EST. If you have an update for me and want to see yourself on :leaderboard_msg_day:’s leaderboard, simply:\n\r   - Go to the [Prove It](:prove_it_link:) section\n\r   - Upload your photo \n\r   - Click “submit your pic”\n\rOn :leaderboard_msg_day:, I will send you the updated standings so you can see yourself on the leaderboard.\n\rRootin’ for ya, :first_name:,\n\r:sender_name:",
             'pro_tip' => null,
+            'signoff' => null,
         ],
         [
             'type' => 'checkin',
@@ -33,6 +35,7 @@ class Correspondence
             'subject' => 'Is everything ok, :first_name:?',
             'body' => "I noticed you haven’t upload a picture of your :reportback_noun: :reportback_verb: to :campaign_title: yet. Just wanted to see if everything is ok!\n\rIf you are able, you still have until :leaderboard_msg_day-1: to be included in the next update! Take a picture and upload your photo [here](:prove_it_link:).\n\rLet me know if I can help you, :first_name:.\n\r:sender_name:",
             'pro_tip' => null,
+            'signoff' => null,
         ],
         [
             'type' => 'reminder',
@@ -41,6 +44,7 @@ class Correspondence
             'subject' => 'Do you have any more :reportback_noun:?',
             'body' => "Hey, :first_name:!\n\rJust a reminder that your next update is due :leaderboard_msg_day-1: before 10:00 PM EST. If you want to see yourself on the leaderboard, [upload a photo](:prove_it_link:) showing you and all :reportback_noun: :reportback_verb:.\n\rOn :leaderboard_msg_day:, I will send you the updated standings.\n\rLet me know if I can help, :first_name:!\n\r:sender_name:",
             'pro_tip' => null,
+            'signoff' => null,
         ],
         [
             'type' => 'reminder',
@@ -49,6 +53,7 @@ class Correspondence
             'subject' => 'Don’t forget to send us your :campaign_title: competition photo!',
             'body' => ":first_name:\n\rYour next update is due tonight before 10pm est, so if you want to make the leaderboard and see your name featured, [upload your photo](:prove_it_link:) with all your :reportback_noun: :reportback_verb:.\n\rCan’t wait to see it!\n\r:sender_name:",
             'pro_tip' => null,
+            'signoff' => null,
         ],
         [
             'type' => 'reminder',
@@ -57,6 +62,7 @@ class Correspondence
             'subject' => 'This :campaign_title: competition is almost over, :first_name:!',
             'body' => "Last call: The final deadline for this competition is this :leaderboard_msg_day-1: night before 10:00 PM EST!\n\rWhen you’re ready, [upload your final photo](:prove_it_link:) showing all your :reportback_noun: :reportback_verb:. If you’re updating your submission with a new photo, simply click “add another photo” and write in how many :reportback_noun: you :reportback_verb:.\n\rLooking forward to seeing your final pic, :first_name:!\n\r:sender_name:",
             'pro_tip' => null,
+            'signoff' => null,
         ],
         [
             'type' => 'reminder',
@@ -65,6 +71,7 @@ class Correspondence
             'subject' => 'LAST CHANCE! The :campaign_title: competition Deadline is now!',
             'body' => ":first_name:,\n\rThe :campaign_title: Competition closes at 10:00 PM EST TONIGHT. Take this moment to [upload your final photo](:prove_it_link:) clearly showing you and all :reportback_noun: :reportback_verb:.\n\rI will send the final results tomorrow, so keep your fingers crossed. Thanks for doing an awesome job to make an impact!\n\r:sender_name:",
             'pro_tip' => null,
+            'signoff' => null,
         ],
         [
             'type' => 'leaderboard',
@@ -73,6 +80,7 @@ class Correspondence
             'subject' => '1st :campaign_title: Leaderboard Update',
             'body' => "Hello Competitors,\n\rHere is your first official :campaign_title: competition update! The competition ends on :end_date:. Finish in the top 3 in :reportback_noun: :reportback_verb: and win:\n\r- 1st place: ­ $100 amex card\r\n- 2nd place: ­ $50 amex card\r\n- 3rd place: ­ $25 amex card\n\rTwo more weeks to increase your number of :reportback_noun: :reportback_verb: to move up the leaderboard! [Upload your photos here](:prove_it_link:).\n\r:pro_tip:\n\rNext :reportback_noun: will be due :leaderboard_msg_day-1: before 10pm est.\n\rHere is the leaderboard! Shoutouts to the top 3 below:",
             'pro_tip' => null,
+            'signoff' => null,
         ],
         [
             'type' => 'leaderboard',
@@ -81,6 +89,7 @@ class Correspondence
             'subject' => 'Leaderboard update #2 for the :campaign_title: competition!',
             'body' => "Hello, competitors-- \n\r1 more week! This :campaign_title: competition ends on :end_date:, so it’s time to make your mark.\n\r:pro_tip:\n\rA final photo with your :reportback_noun: will be due :leaderboard_msg_day-1: before 10pm EST. [Upload yours here](:prove_it_link:).\n\rHere is the leaderboard! Shoutouts to the top 3 below:\n\r1 more week to make your mark and climb up the leaderboard!",
             'pro_tip' => null,
+            'signoff' => "1 more week to make your mark and climb up the leaderboard!",
         ],
         [
             'type' => 'leaderboard',
@@ -89,9 +98,9 @@ class Correspondence
             'subject' => 'Here are the :campaign_title: competition winners!',
             'body' => "This is it, the final leaderboard and results. Thank you for spending these last 3 weeks, working hard not only to climb the leaderboard, but also to affect lives around you and make the world a better place.\n\rHere is your final leaderboard. Pics, prizes and honorable mentions below:\n\r",
             'pro_tip' => null,
+            'signoff' => null,
         ],
     ];
-
     /**
      * Get all default messages.
      *

--- a/app/Http/Utilities/Correspondence.php
+++ b/app/Http/Utilities/Correspondence.php
@@ -101,6 +101,7 @@ class Correspondence
             'signoff' => null,
         ],
     ];
+
     /**
      * Get all default messages.
      *

--- a/app/Http/Utilities/Email.php
+++ b/app/Http/Utilities/Email.php
@@ -91,7 +91,7 @@ class Email
      */
     protected function processMessage($tokens, $message)
     {
-        $parsableProperties = ['subject', 'body', 'pro_tip'];
+        $parsableProperties = ['subject', 'body', 'signoff', 'pro_tip'];
 
         $processedMessage['type'] = $message->type;
 

--- a/app/Http/Utilities/Email.php
+++ b/app/Http/Utilities/Email.php
@@ -93,12 +93,12 @@ class Email
     {
         $parsableProperties = ['subject', 'body', 'pro_tip'];
 
-        $processedMessage = clone $message;
+        $processedMessage['type'] = $message->type;
 
         foreach ($parsableProperties as $prop) {
-            $processedMessage->$prop = $this->replaceTokens($tokens, $message->$prop);
-            $processedMessage->$prop = $this->parseLinks($processedMessage->$prop);
-            $processedMessage->$prop = nl2br($processedMessage->$prop);
+            $processedMessage[$prop] = $this->replaceTokens($tokens, $message->$prop);
+            $processedMessage[$prop] = $this->parseLinks($processedMessage[$prop]);
+            $processedMessage[$prop] = nl2br($processedMessage[$prop]);
         }
 
         return $processedMessage;

--- a/app/Listeners/QueueMessage.php
+++ b/app/Listeners/QueueMessage.php
@@ -6,7 +6,7 @@ use Illuminate\Mail\Mailer;
 use Gladiator\Events\QueueMessageRequest;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Gladiator\Models\Message;
-use Gladiator\Http\Utilities\Email;
+use Gladiator\Services\Email;
 
 class QueueMessage implements ShouldQueue
 {
@@ -33,7 +33,7 @@ class QueueMessage implements ShouldQueue
         $resources = $event->resources;
 
         // Build the email.
-        $email = new Email($resources['message'], $resources['contest'], $resources['competition'], $resources['users']);
+        $email = new Email($resources);
 
         foreach ($email->allMessages as $content) {
             $settings = [

--- a/app/Listeners/QueueMessage.php
+++ b/app/Listeners/QueueMessage.php
@@ -33,7 +33,8 @@ class QueueMessage implements ShouldQueue
         $resources = $event->resources;
 
         // Build the email.
-        $email = new Email($resources);
+        $manager = app(\Gladiator\Services\Manager::class);
+        $email = new Email($resources, $manager);
 
         foreach ($email->allMessages as $content) {
             $settings = [

--- a/app/Listeners/QueueMessage.php
+++ b/app/Listeners/QueueMessage.php
@@ -33,8 +33,7 @@ class QueueMessage implements ShouldQueue
         $resources = $event->resources;
 
         // Build the email.
-        $manager = app(\Gladiator\Services\Manager::class);
-        $email = new Email($resources, $manager);
+        $email = new Email($resources);
 
         foreach ($email->allMessages as $content) {
             $settings = [

--- a/app/Listeners/QueueMessage.php
+++ b/app/Listeners/QueueMessage.php
@@ -35,18 +35,16 @@ class QueueMessage implements ShouldQueue
         // Build the email.
         $email = new Email($resources['message'], $resources['contest'], $resources['competition'], $resources['users']);
 
-        foreach ($email->allMessages as $message) {
-            $content = $message['message'];
-
+        foreach ($email->allMessages as $content) {
             $settings = [
-                'subject' => $content->subject,
+                'subject' => $content['message']['subject'],
                 'from' => $email->contest->sender_email,
                 'from_name' => $email->contest->sender_name,
-                'to' => $message['user']->email,
-                'to_name' => $message['user']->first_name,
+                'to' => $content['user']->email,
+                'to_name' => $content['user']->first_name,
             ];
 
-            $this->sendMail($content, $settings);
+            $this->sendMail($content['message'], $settings);
         }
     }
 
@@ -58,7 +56,7 @@ class QueueMessage implements ShouldQueue
      */
     public function sendMail($content, $settings)
     {
-        $this->mail->queue('messages.' . $content->type, ['body' => $content->body], function ($msg) use ($settings) {
+        $this->mail->queue('messages.' . $content['type'], ['content' => $content], function ($msg) use ($settings) {
             $msg->from($settings['from'], $settings['from_name']);
 
             $msg->to($settings['to'], $settings['to_name'])->subject($settings['subject']);

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -5,7 +5,6 @@ namespace Gladiator\Services;
 use Gladiator\Models\Contest;
 use Gladiator\Models\Competition;
 use Gladiator\Models\Message;
-use Gladiator\Services\Manager;
 
 class Email
 {
@@ -144,8 +143,7 @@ class Email
 
             // Leaderboard messages get an extra leaderboard variable to be sent to the email template.
             // @TODO - move into smaller function that gets the leaderboard and then add it to the allMessages array here.
-            if ($this->message->type == 'leaderboard')
-            {
+            if ($this->message->type == 'leaderboard') {
                 $list = $this->manager->catalogUsers($this->users);
 
                 $this->allMessages[$key]['message']['leaderboard'] = $list['active'];

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Gladiator\Http\Utilities;
+namespace Gladiator\Services;
 
 use Gladiator\Models\Contest;
 use Gladiator\Models\Competition;
 use Gladiator\Models\Message;
-use Gladiator\Services\Manager;
+// use Gladiator\Services\Manager;
 
 class Email
 {
@@ -47,15 +47,15 @@ class Email
     /**
      * Constructor
      */
-    public function __construct(Message $message, Contest $contest, Competition $competition, Manager $manager, $users)
+    public function __construct($resources)
     {
-        $this->message = $message;
-        $this->contest = $contest;
-        $this->competition = $competition;
-        $this->users = $users;
+        $this->message = $resources['message'];
+        $this->contest = $resources['contest'];
+        $this->competition = $resources['competition'];
+        $this->users = $resources['users'];
         // @TODO - is there a better way of instantiating and pulling in the manager class?
         // Maybe this email class needs to be a service instead.
-        $this->manager = $manager;
+        // $this->manager = $manager;
 
         $this->setupEmail();
     }
@@ -144,12 +144,12 @@ class Email
 
             // Leaderboard messages get an extra leaderboard variable to be sent to the email template.
             // @TODO - move into smaller function that gets the leaderboard and then add it to the allMessages array here.
-            if ($this->message->type == 'leaderboard')
-            {
-                $list = $this->manager->catalogUsers($users);
+            // if ($this->message->type == 'leaderboard')
+            // {
+            //     $list = $this->manager->catalogUsers($users);
 
-                $this->allMessages[$key]['message']['leaderboard'] = $list['active'];
-            }
+            //     $this->allMessages[$key]['message']['leaderboard'] = $list['active'];
+            // }
 
             // @TODO - create a smaller function that can be called here that gets the top 3 reportbacks.
         }

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -46,15 +46,14 @@ class Email
     /**
      * Constructor
      */
-    public function __construct($resources, Manager $manager)
+    public function __construct($resources)
     {
         $this->message = $resources['message'];
         $this->contest = $resources['contest'];
         $this->competition = $resources['competition'];
         $this->users = $resources['users'];
-        // @TODO - is there a better way of instantiating and pulling in the manager class?
-        // Maybe this email class needs to be a service instead.
-        $this->manager = $manager;
+
+        $this->manager = app(\Gladiator\Services\Manager::class);
 
         $this->setupEmail();
     }

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -5,7 +5,7 @@ namespace Gladiator\Services;
 use Gladiator\Models\Contest;
 use Gladiator\Models\Competition;
 use Gladiator\Models\Message;
-// use Gladiator\Services\Manager;
+use Gladiator\Services\Manager;
 
 class Email
 {
@@ -47,7 +47,7 @@ class Email
     /**
      * Constructor
      */
-    public function __construct($resources)
+    public function __construct($resources, Manager $manager)
     {
         $this->message = $resources['message'];
         $this->contest = $resources['contest'];
@@ -55,7 +55,7 @@ class Email
         $this->users = $resources['users'];
         // @TODO - is there a better way of instantiating and pulling in the manager class?
         // Maybe this email class needs to be a service instead.
-        // $this->manager = $manager;
+        $this->manager = $manager;
 
         $this->setupEmail();
     }
@@ -144,12 +144,12 @@ class Email
 
             // Leaderboard messages get an extra leaderboard variable to be sent to the email template.
             // @TODO - move into smaller function that gets the leaderboard and then add it to the allMessages array here.
-            // if ($this->message->type == 'leaderboard')
-            // {
-            //     $list = $this->manager->catalogUsers($users);
+            if ($this->message->type == 'leaderboard')
+            {
+                $list = $this->manager->catalogUsers($this->users);
 
-            //     $this->allMessages[$key]['message']['leaderboard'] = $list['active'];
-            // }
+                $this->allMessages[$key]['message']['leaderboard'] = $list['active'];
+            }
 
             // @TODO - create a smaller function that can be called here that gets the top 3 reportbacks.
         }

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -143,11 +143,11 @@ class Email
 
             // Leaderboard messages get an extra leaderboard variable to be sent to the email template.
             // @TODO - move into smaller function that gets the leaderboard and then add it to the allMessages array here.
-            if ($this->message->type == 'leaderboard') {
-                $list = $this->manager->catalogUsers($this->users);
+            // if ($this->message->type == 'leaderboard') {
+            //     $list = $this->manager->catalogUsers($this->users);
 
-                $this->allMessages[$key]['message']['leaderboard'] = $list['active'];
-            }
+            //     $this->allMessages[$key]['message']['leaderboard'] = $list['active'];
+            // }
 
             // @TODO - create a smaller function that can be called here that gets the top 3 reportbacks.
         }

--- a/database/migrations/2016_04_14_140824_add_signoff_to_messages.php
+++ b/database/migrations/2016_04_14_140824_add_signoff_to_messages.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddSignoffToMessages extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->longtext('signoff')->nullable()->after('body');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->dropColumn('signoff');
+        });
+    }
+}

--- a/database/seeds/MessageTableSeeder.php
+++ b/database/seeds/MessageTableSeeder.php
@@ -35,6 +35,7 @@ class MessageTableSeeder extends Seeder
                 'subject' => $data['subject'],
                 'body' => $data['body'],
                 'label' => $data['label'],
+                'signoff' => $data['signoff'],
             ];
         }
 

--- a/resources/views/contests/partials/_form_contest_messaging.blade.php
+++ b/resources/views/contests/partials/_form_contest_messaging.blade.php
@@ -16,5 +16,10 @@
         <textarea class="text-field" name="{{ correspondence()->getAttribute($message, 'pro_tip') }}" id="{{ correspondence()->getAttribute($message, 'pro_tip') }}" rows="3">{{ correspondence($message, 'pro_tip') }}</textarea>
     @endif
 
+    <div class="form-item -padded">
+        <label class="field-label" for="{{ correspondence()->getAttribute($message, 'signoff') }}">Signoff:</label>
+        <textarea class="text-field" name="{{ correspondence()->getAttribute($message, 'signoff') }}" id="{{ correspondence()->getAttribute($message, 'signoff') }}" rows="10">{{ correspondence($message, 'signoff') }}</textarea>
+    </div>
+
     <input type="hidden" name="{{ correspondence()->getAttribute($message, 'label') }}" value="{{ correspondence($message, 'label') }}" />
 </fieldset>

--- a/resources/views/contests/partials/_form_contest_messaging.blade.php
+++ b/resources/views/contests/partials/_form_contest_messaging.blade.php
@@ -19,7 +19,7 @@
 
         <div class="form-item -padded">
             <label class="field-label" for="{{ correspondence()->getAttribute($message, 'signoff') }}">Signoff:</label>
-            <textarea class="text-field" name="{{ correspondence()->getAttribute($message, 'signoff') }}" id="{{ correspondence()->getAttribute($message, 'signoff') }}" rows="10">{{ correspondence($message, 'signoff') }}</textarea>
+            <textarea class="text-field" name="{{ correspondence()->getAttribute($message, 'signoff') }}" id="{{ correspondence()->getAttribute($message, 'signoff') }}" rows="3">{{ correspondence($message, 'signoff') }}</textarea>
         </div>
     @endif
 

--- a/resources/views/contests/partials/_form_contest_messaging.blade.php
+++ b/resources/views/contests/partials/_form_contest_messaging.blade.php
@@ -12,14 +12,16 @@
     </div>
 
     @if ($message['type'] === 'leaderboard')
-        <label class="field-label" for="{{ correspondence()->getAttribute($message, 'pro_tip') }}">Pro Tip:</label>
-        <textarea class="text-field" name="{{ correspondence()->getAttribute($message, 'pro_tip') }}" id="{{ correspondence()->getAttribute($message, 'pro_tip') }}" rows="3">{{ correspondence($message, 'pro_tip') }}</textarea>
-    @endif
+        <div class="form-item -padded">
+            <label class="field-label" for="{{ correspondence()->getAttribute($message, 'pro_tip') }}">Pro Tip:</label>
+            <textarea class="text-field" name="{{ correspondence()->getAttribute($message, 'pro_tip') }}" id="{{ correspondence()->getAttribute($message, 'pro_tip') }}" rows="3">{{ correspondence($message, 'pro_tip') }}</textarea>
+        </div>
 
-    <div class="form-item -padded">
-        <label class="field-label" for="{{ correspondence()->getAttribute($message, 'signoff') }}">Signoff:</label>
-        <textarea class="text-field" name="{{ correspondence()->getAttribute($message, 'signoff') }}" id="{{ correspondence()->getAttribute($message, 'signoff') }}" rows="10">{{ correspondence($message, 'signoff') }}</textarea>
-    </div>
+        <div class="form-item -padded">
+            <label class="field-label" for="{{ correspondence()->getAttribute($message, 'signoff') }}">Signoff:</label>
+            <textarea class="text-field" name="{{ correspondence()->getAttribute($message, 'signoff') }}" id="{{ correspondence()->getAttribute($message, 'signoff') }}" rows="10">{{ correspondence($message, 'signoff') }}</textarea>
+        </div>
+    @endif
 
     <input type="hidden" name="{{ correspondence()->getAttribute($message, 'label') }}" value="{{ correspondence($message, 'label') }}" />
 </fieldset>

--- a/resources/views/contests/partials/_form_contest_messaging.blade.php
+++ b/resources/views/contests/partials/_form_contest_messaging.blade.php
@@ -21,6 +21,8 @@
             <label class="field-label" for="{{ correspondence()->getAttribute($message, 'signoff') }}">Signoff:</label>
             <textarea class="text-field" name="{{ correspondence()->getAttribute($message, 'signoff') }}" id="{{ correspondence()->getAttribute($message, 'signoff') }}" rows="3">{{ correspondence($message, 'signoff') }}</textarea>
         </div>
+
+        <!-- @TODO: add leaderboard and reportback checkboxes -->
     @endif
 
     <input type="hidden" name="{{ correspondence()->getAttribute($message, 'label') }}" value="{{ correspondence($message, 'label') }}" />

--- a/resources/views/messages/checkin.blade.php
+++ b/resources/views/messages/checkin.blade.php
@@ -1,1 +1,1 @@
-{!! $body !!}
+{!! $content['body'] !!}

--- a/resources/views/messages/leaderboard.blade.php
+++ b/resources/views/messages/leaderboard.blade.php
@@ -1,3 +1,4 @@
 {!! $content['body'] !!}
 <br><br>
+{{-- @TODO: check if leaderboard exists and checkbox to include it is checked, then pull in the leaderboard partial here. --}}
 {!! $content['signoff'] !!}

--- a/resources/views/messages/leaderboard.blade.php
+++ b/resources/views/messages/leaderboard.blade.php
@@ -1,1 +1,3 @@
-{!! $body !!}
+{!! $content['body'] !!}
+<br><br>
+{!! $content['signoff'] !!}

--- a/resources/views/messages/reminder.blade.php
+++ b/resources/views/messages/reminder.blade.php
@@ -1,1 +1,1 @@
-{!! $body !!}
+{!! $content['body'] !!}

--- a/resources/views/messages/welcome.blade.php
+++ b/resources/views/messages/welcome.blade.php
@@ -1,1 +1,1 @@
-{!! $body !!}
+{!! $content['body'] !!}


### PR DESCRIPTION
#### What's this PR do?
This PR is part 1 of getting leaderboards in Email messages. 

* Create a new `signoff` field that admins can use to place text after the leaderboard is injected into the email template.

* Updates how we were creating process messages, before I was making a processed version of the `Message` instance for each user, when really we just needed a few of the processed fields. So now it just creates an array with the fields we need. See below for way an array is needed and fine for this.

* Passing an `Array` containing all the variables needed for output to the message view instead of an `Object` because when using `Mail::queue` Laravel will create a raw serialized array of what is passed to the view, so we need to use array notation anyway. 

* Updates the message views accordingly.

#### Any background context you want to provide?
Pushing this up now for review and so we can unblock #229 and #206 

#### What are the relevant tickets?
Addresses #195 