### PR TITLE
Quick update to allow easily adding mutators for Message attributes.

### DIFF
--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class Message extends Model
 {
-    protected $fillable = ['contest_id', 'type', 'key', 'label', 'subject', 'body', 'pro_tip'];
+    protected $fillable = ['contest_id', 'type', 'key', 'label', 'subject', 'body', 'pro_tip', 'signoff'];
 
     /**
      * Array of available message types.
@@ -26,6 +26,16 @@ class Message extends Model
     public function contest()
     {
         return $this->belongsTo(Contest::class);
+    }
+
+    /**
+     * Set the pro_tip attribute for the message.
+     *
+     * @param string  $value
+     */
+    public function setProTipAttribute($value)
+    {
+        $this->attributes['pro_tip'] = empty($value) ? null : $value;
     }
 
     /**

--- a/app/Repositories/MessageRepository.php
+++ b/app/Repositories/MessageRepository.php
@@ -16,7 +16,6 @@ class MessageRepository
     public function create($contest, $data)
     {
         $message = new Message($data);
-        $message->pro_tip = empty($data['pro_tip']) ? null : $data['pro_tip'];
 
         return $contest->messages()->save($message);
     }
@@ -51,9 +50,14 @@ class MessageRepository
     public function update($contest, $data)
     {
         $message = Message::where('contest_id', '=', $contest->id)->where('type', '=', $data['type'])->where('key', '=', $data['key'])->firstOrFail();
-        $message->subject = $data['subject'];
-        $message->body = $data['body'];
-        $message->pro_tip = empty($data['pro_tip']) ? null : $data['pro_tip'];
+
+        $attributes = $message->getFillable();
+
+        foreach ($attributes as $attribute) {
+            if (isset($data[$attribute])) {
+                $message->{$attribute} = $data[$attribute];
+            }
+        }
 
         return $message->save();
     }

--- a/database/seeds/MessageTableSeeder.php
+++ b/database/seeds/MessageTableSeeder.php
@@ -35,6 +35,7 @@ class MessageTableSeeder extends Seeder
                 'subject' => $data['subject'],
                 'body' => $data['body'],
                 'label' => $data['label'],
+                'pro_tip' => $data['pro_tip'],
                 'signoff' => $data['signoff'],
             ];
         }

--- a/resources/views/contests/partials/_form_contest_messaging.blade.php
+++ b/resources/views/contests/partials/_form_contest_messaging.blade.php
@@ -22,7 +22,7 @@
             <textarea class="text-field" name="{{ correspondence()->getAttribute($message, 'signoff') }}" id="{{ correspondence()->getAttribute($message, 'signoff') }}" rows="3">{{ correspondence($message, 'signoff') }}</textarea>
         </div>
 
-        <!-- @TODO: add leaderboard and reportback checkboxes -->
+        {{-- @TODO: add leaderboard and reportback checkboxes --}}
     @endif
 
     <input type="hidden" name="{{ correspondence()->getAttribute($message, 'label') }}" value="{{ correspondence($message, 'label') }}" />


### PR DESCRIPTION
#### What's this PR do?
This PR does a quick update to how Message updating is handled and allows setting up mutators in the Message model for the different attributes we are adding as messages evolves.

#### How should this be manually tested?
Try editing messages for a contest, particularly the `pro_tip` and `signoff` fields and make sure the values you entered stick after submitting the form.

#### Any background context you want to provide?
@angaither looked further into this, and it seems the capability to use the `set*Attribute()` method on the model depends on right before saving the model, that the actual attribute is directly called. So if you want to create a setter for `pro_tip`, you can't just use the `fill()` method and pass it the input, you specifically need to do:

```php
$message->pro_tip = $data['pro_tip']
```

The above actually activates the `setProTipAttribute($value)` method on the `Message` model.

You can find more info here: https://laravel.com/docs/5.2/eloquent-mutators#accessors-and-mutators

I did take your advice though to make it easier when setting the attributes by first grabbing the array items from the `fillable` property, and [did it in a way](https://github.com/DoSomething/gladiator/compare/messages-update-refactor?expand=1#diff-0611f5ce25165dc163f30daf92ee8c7bR58) that still allows accessing `setter` mutators on each attribute 💃 

#### What are the relevant tickets?
Refs #206