### PR TITLE
Message refills

### DIFF
--- a/app/Console/Commands/UpdateMessages.php
+++ b/app/Console/Commands/UpdateMessages.php
@@ -15,7 +15,7 @@ class UpdateMessages extends Command
      *
      * @var string
      */
-    protected $signature = 'update:messages {contest?} {--override : Override all contest messages and refresh with latest defaults }';
+    protected $signature = 'update:messages {contest?}';
 
     /**
      * The console command description.

--- a/app/Console/Commands/UpdateMessages.php
+++ b/app/Console/Commands/UpdateMessages.php
@@ -2,6 +2,7 @@
 
 namespace Gladiator\Console\Commands;
 
+use Gladiator\Models\Contest;
 use Illuminate\Console\Command;
 
 class UpdateMessages extends Command
@@ -11,14 +12,14 @@ class UpdateMessages extends Command
      *
      * @var string
      */
-    protected $signature = 'update:messages {contest?}';
+    protected $signature = 'update:messages {contest?} {--override : Override all contest messages and refresh with latest defaults }';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Command description';
+    protected $description = 'Update correspondence messages for all contests as needed';
 
     /**
      * Create a new command instance.
@@ -37,6 +38,12 @@ class UpdateMessages extends Command
      */
     public function handle()
     {
-        //
+        $contest = $this->argument('contest');
+
+        if ($contest) {
+            $contest = Contest::findOrFail($contest);
+
+            dd($contest);
+        }
     }
 }

--- a/app/Console/Commands/UpdateMessages.php
+++ b/app/Console/Commands/UpdateMessages.php
@@ -3,10 +3,13 @@
 namespace Gladiator\Console\Commands;
 
 use Gladiator\Models\Contest;
+use Gladiator\Repositories\MessageRepository;
 use Illuminate\Console\Command;
 
 class UpdateMessages extends Command
 {
+    protected $repository;
+
     /**
      * The name and signature of the console command.
      *
@@ -24,11 +27,14 @@ class UpdateMessages extends Command
     /**
      * Create a new command instance.
      *
+     * @param \Gladiator\Repositories\MessageRepository  $repository
      * @return void
      */
-    public function __construct()
+    public function __construct(MessageRepository $repository)
     {
         parent::__construct();
+
+        $this->repository = $repository;
     }
 
     /**
@@ -40,10 +46,22 @@ class UpdateMessages extends Command
     {
         $contest = $this->argument('contest');
 
+        $messages = $this->repository->buildMessagesFromDefaults();
+
         if ($contest) {
             $contest = Contest::findOrFail($contest);
 
-            dd($contest);
+            $this->repository->updateMessagesForContest($contest, $messages);
+
+            return $this->comment(PHP_EOL . 'All set! Messages for Contest ID #' . $contest->id . ' have been updated. If any messages were missing, they were added as well!' . PHP_EOL);
         }
+
+        $contests = Contest::all();
+
+        foreach ($contests as $contest) {
+            $this->repository->updateMessagesForContest($contest, $messages);
+        }
+
+        return $this->comment(PHP_EOL . 'All set! Messages for all Contests have been updated. If any messages for a Contest were missing, they were added as well!' . PHP_EOL);
     }
 }

--- a/app/Console/Commands/UpdateMessages.php
+++ b/app/Console/Commands/UpdateMessages.php
@@ -54,14 +54,14 @@ class UpdateMessages extends Command
             $this->repository->updateMessagesForContest($contest, $messages);
 
             return $this->comment(PHP_EOL . 'All set! Messages for Contest ID #' . $contest->id . ' have been updated. If any messages were missing, they were added as well!' . PHP_EOL);
+        } else {
+            $contests = Contest::all();
+
+            foreach ($contests as $contest) {
+                $this->repository->updateMessagesForContest($contest, $messages);
+            }
+
+            return $this->comment(PHP_EOL . 'All set! Messages for all Contests have been updated. If any messages for a Contest were missing, they were added as well!' . PHP_EOL);
         }
-
-        $contests = Contest::all();
-
-        foreach ($contests as $contest) {
-            $this->repository->updateMessagesForContest($contest, $messages);
-        }
-
-        return $this->comment(PHP_EOL . 'All set! Messages for all Contests have been updated. If any messages for a Contest were missing, they were added as well!' . PHP_EOL);
     }
 }

--- a/app/Console/Commands/UpdateMessages.php
+++ b/app/Console/Commands/UpdateMessages.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Gladiator\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class UpdateMessages extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'update:messages {contest?}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        //
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,6 +15,7 @@ class Kernel extends ConsoleKernel
     protected $commands = [
         Commands\Inspire::class,
         Commands\AddUser::class,
+        Commands\UpdateMessages::class,
     ];
 
     /**

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -6,19 +6,26 @@ use Illuminate\Database\Eloquent\Model;
 
 class Message extends Model
 {
+    /**
+     * Get the fillable attributes for the model.
+     *
+     * @return array
+     */
     protected $fillable = ['contest_id', 'type', 'key', 'label', 'subject', 'body', 'pro_tip', 'signoff'];
+
+    /**
+     * Excluded attributes that are not customizeable.
+     *
+     * @var array
+     */
+    protected $excludedAttributes = ['contest_id', 'type', 'key'];
 
     /**
      * Array of available message types.
      *
      * @var array
      */
-    protected static $types = [
-        'checkin',
-        'leaderboard',
-        'reminder',
-        'welcome',
-    ];
+    protected static $types = [ 'checkin', 'leaderboard', 'reminder', 'welcome' ];
 
     /**
      * Get the contest associated with this message.
@@ -26,6 +33,16 @@ class Message extends Model
     public function contest()
     {
         return $this->belongsTo(Contest::class);
+    }
+
+    /**
+     * Get the list of excluded attributes.
+     *
+     * @return array
+     */
+    public function getExcludedAttributes()
+    {
+        return $this->excludedAttributes;
     }
 
     /**

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -25,7 +25,7 @@ class Message extends Model
      *
      * @var array
      */
-    protected static $types = [ 'checkin', 'leaderboard', 'reminder', 'welcome' ];
+    protected static $types = ['checkin', 'leaderboard', 'reminder', 'welcome'];
 
     /**
      * Get the contest associated with this message.

--- a/app/Repositories/MessageRepository.php
+++ b/app/Repositories/MessageRepository.php
@@ -40,10 +40,36 @@ class MessageRepository
         }
     }
 
+    /**
+     * Build the series of messages from the Correspondence defaults.
+     *
+     * @return array
+     */
     public function buildMessagesFromDefaults()
     {
+        $messages = [];
+
         $defaults = correspondence()->defaults();
 
+        $model = new Message;
+        $types = $model->getTypes();
+        $attributes = array_diff($model->getFillable(), $model->getExcludedAttributes());
+
+        foreach ($types as $type) {
+            $messages[$type] = [];
+        }
+
+        foreach ($defaults as $data) {
+            $fields = [];
+
+            foreach ($attributes as $attribute) {
+                $fields[$attribute] = $data[$attribute];
+            }
+
+            $messages[$data['type']][] = $fields;
+        }
+
+        return $messages;
     }
 
     /**
@@ -55,7 +81,11 @@ class MessageRepository
      */
     public function update($contest, $data)
     {
-        $message = Message::where('contest_id', '=', $contest->id)->where('type', '=', $data['type'])->where('key', '=', $data['key'])->firstOrFail();
+        $message = Message::where('contest_id', '=', $contest->id)->where('type', '=', $data['type'])->where('key', '=', $data['key'])->first();
+
+        if (! $message) {
+            return $this->create($contest, $data);
+        }
 
         $attributes = $message->getFillable();
 

--- a/app/Repositories/MessageRepository.php
+++ b/app/Repositories/MessageRepository.php
@@ -40,6 +40,12 @@ class MessageRepository
         }
     }
 
+    public function buildMessagesFromDefaults()
+    {
+        $defaults = correspondence()->defaults();
+
+    }
+
     /**
      * Update a message.
      *

--- a/database/seeds/MessageTableSeeder.php
+++ b/database/seeds/MessageTableSeeder.php
@@ -7,15 +7,18 @@ use Illuminate\Database\Seeder;
 
 class MessageTableSeeder extends Seeder
 {
+    /**
+     * MessageRepository instance.
+     *
+     * @var \Gladiator\Repositories\MessageRepository
+     */
     protected $repository;
 
     /**
-     * Attributes to exclude when seeding default messages.
+     * Create a new message table seeder instance.
      *
-     * @var array
+     * @param \Gladiator\Repositories\MessageRepository  $repository
      */
-    protected $excludedAttributes = ['contest_id', 'type', 'key'];
-
     public function __construct(MessageRepository $repository)
     {
         $this->repository = $repository;
@@ -28,29 +31,9 @@ class MessageTableSeeder extends Seeder
      */
     public function run()
     {
-        $defaults = correspondence()->defaults();
-        $messages = [];
-
         $contests = Contest::all();
 
-        $model = new Message;
-        $types = $model->getTypes();
-        $attributes = $model->getFillable();
-        $attributes = array_diff($attributes, $this->excludedAttributes);
-
-        foreach ($types as $type) {
-            $messages[$type] = [];
-        }
-
-        foreach ($defaults as $data) {
-            $fields = [];
-
-            foreach ($attributes as $attribute) {
-                $fields[$attribute] = $data[$attribute];
-            }
-
-            $messages[$data['type']][] = $fields;
-        }
+        $messages = $this->repository->buildMessagesFromDefaults();
 
         foreach ($contests as $contest) {
             if (! $contest->messages->count()) {

--- a/database/seeds/MessageTableSeeder.php
+++ b/database/seeds/MessageTableSeeder.php
@@ -9,6 +9,13 @@ class MessageTableSeeder extends Seeder
 {
     protected $repository;
 
+    /**
+     * Attributes to exclude when seeding default messages.
+     *
+     * @var array
+     */
+    protected $excludedAttributes = ['contest_id', 'type', 'key'];
+
     public function __construct(MessageRepository $repository)
     {
         $this->repository = $repository;
@@ -21,23 +28,28 @@ class MessageTableSeeder extends Seeder
      */
     public function run()
     {
-        $contests = Contest::all();
         $defaults = correspondence()->defaults();
-        $types = Message::getTypes();
         $messages = [];
+
+        $contests = Contest::all();
+
+        $model = new Message;
+        $types = $model->getTypes();
+        $attributes = $model->getFillable();
+        $attributes = array_diff($attributes, $this->excludedAttributes);
 
         foreach ($types as $type) {
             $messages[$type] = [];
         }
 
         foreach ($defaults as $data) {
-            $messages[$data['type']][] = [
-                'subject' => $data['subject'],
-                'body' => $data['body'],
-                'label' => $data['label'],
-                'pro_tip' => $data['pro_tip'],
-                'signoff' => $data['signoff'],
-            ];
+            $fields = [];
+
+            foreach ($attributes as $attribute) {
+                $fields[$attribute] = $data[$attribute];
+            }
+
+            $messages[$data['type']][] = $fields;
         }
 
         foreach ($contests as $contest) {


### PR DESCRIPTION
#### What's this PR do?
This PR updates the `MessageTableSeeder` to work a little smarter, and keep us from having to modify multiple places if/when we add new fields to the default message structure. It then uses a similar approach to build out the new `updated:messages` artisan console command, which will update all messages in a contest(s), and if any are missing, based on the list of defaults, will create the missing ones.

This command can be called in one of two ways:

1) To update **all** messages for **every** contest.
```shell
$ php artisan update:messages
```

2) To update only a specified contest.
```shell
$ php artisan update:messages 12
```
Where `12` is the ID of a specific contest.

This PR also creates a new `buildMessagesFromDefaults()` method on the `MessageRepository` class which builds out all the default messages into an easy to use array.

#### How should this be manually tested?
Head into SequelPro and wreck all kinds of havoc inside the `messages` table. Delete rows, change the values to random strings (I recommend the use of the string `poopie`). Then run the command, refresh SequelPro and see if everything is fixed!

#### What are the relevant tickets?
Fixes #206

---
@DoSomething/gladiator 