### PR TITLE
No more silly homepage and other cleanup.

### DIFF
--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -14,7 +14,7 @@
 Route::group(['middleware' => ['web']], function () {
 
     Route::get('/', function () {
-        return redirect()->route('users.index');
+        return redirect()->route('contests.index');
     });
 
     // Authentication

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -14,7 +14,7 @@
 Route::group(['middleware' => ['web']], function () {
 
     Route::get('/', function () {
-        return view('pages.home');
+        return redirect()->route('users.index');
     });
 
     // Authentication

--- a/resources/views/pages/dashboard.blade.php
+++ b/resources/views/pages/dashboard.blade.php
@@ -1,0 +1,1 @@
+{{-- More to come. --}}

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -10,7 +10,6 @@
         <div class="wrapper">
             <div class="container__block">
                 <a class="button" href="{{ route('users.create') }}">Add User</a>
-                <a class="button" href="{{ route('users.contestants') }}">Contestants</a>
             </div>
         </div>
     </div>
@@ -22,5 +21,13 @@
     @if ($staff->count())
         @include('users.partials._table_users', ['users' => $staff, 'role' => 'Staff'])
     @endif
+
+    <div class="container">
+        <div class="wrapper">
+            <div class="container__block">
+                <p>View the list of all <a href="{{ route('users.contestants') }}">Contestants</a> in Gladiator.</p>
+            </div>
+        </div>
+    </div>
 
 @stop


### PR DESCRIPTION
#### What's this PR do?
This PR fixes the `Contestants` view button to make it a more subtle link... too many of those big buttons up top is jarring on the 👀 : 

![image](https://cloud.githubusercontent.com/assets/105849/14753651/ad3b4db2-08a4-11e6-8080-7ff72271e424.png)

Also updates the root (home) route so it redirects to the ~~users~~ contests index page instead of the super awesome, **All Your Base Are Belong To Us** welcome page. Sad to see it go, but alas. If you're not logged in, then it'll just send you straight to the login page ⛔ 

#### How should this be manually tested?
Try going to the home page when logged out. Do you see the login form?

#### What are the relevant tickets?
Fixes 🌎 

---
@DoSomething/gladiator 