### PR TITLE
Rest api client updates

### DIFF
--- a/app/Services/RestApiClient.php
+++ b/app/Services/RestApiClient.php
@@ -174,7 +174,6 @@ class RestApiClient
      */
     protected function setMessages($error)
     {
-        // dd('errors');
         // @TODO: may eventually need to handle an array of errors.
         return (new MessageBag)->add($error->code, $error->message);
     }

--- a/app/Services/RestApiClient.php
+++ b/app/Services/RestApiClient.php
@@ -132,6 +132,7 @@ class RestApiClient
             return $this->client->request($method, $path, $options);
         } catch (RequestException $error) {
             $response = $this->getJson($error->getResponse());
+            $response = $this->setErrorCode($response, $error->getCode());
 
             if ($error->getCode() === 404) {
                 $messages = $this->setMessages($response->error);
@@ -151,12 +152,29 @@ class RestApiClient
     }
 
     /**
+     * Set the error code on the response error object if missing.
+     *
+     * @param  object  $response
+     * @param  string  $code
+     * @return object
+     */
+    protected function setErrorCode($response, $code)
+    {
+        if (! property_exists($response->error, 'code')) {
+            $response->error->code = $code;
+        }
+
+        return $response;
+    }
+
+    /**
      * Set any erorr message within a MessageBag.
      *
      * @param object  $error
      */
     protected function setMessages($error)
     {
+        // dd('errors');
         // @TODO: may eventually need to handle an array of errors.
         return (new MessageBag)->add($error->code, $error->message);
     }


### PR DESCRIPTION
#### What's this PR do?
This PR fixes a bug that was occurring when we would receive an error response from the Phoenix API. The `RestApiClient` class was expecting the format for error responses in the way that Northstar formats them, which is slightly different than how Phoenix does. This fix updates the response object to include the expected `code` property in the `error` object.

#### How should this be manually tested?
Do you still get the "Undefined property: stdClass::$code" error?

#### Any background context you want to provide?
Tested this a bit with forcing errors from Phoenix, but definitely something to keep an eye out for if it crops up again!

#### What are the relevant tickets?
Fixes #180 


---
@DoSomething/gladiator 
