### PR TITLE
Emails welcome

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -92,7 +92,7 @@ class UsersController extends ApiController
             'message' => $message,
             'contest' => $contest,
             'users' => [$user],
-            'test' => true,
+            'test' => false,
         ];
         event(new QueueMessageRequest($resources));
 

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -86,7 +86,7 @@ class UsersController extends ApiController
         $this->manager->appendCampaign($contest);
 
         // Fire off welcome Email
-        $message = Message::where(['contest_id' => $contest->id, 'type' => 'Welcome'])->first();
+        $message = Message::where(['contest_id' => $contest->id, 'type' => 'welcome'])->first();
         $resources = [
             'message' => $message,
             'contest' => $contest,

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -9,7 +9,6 @@ use Gladiator\Services\Manager;
 use Gladiator\Http\Requests\UserRequest;
 use Gladiator\Http\Transformers\UserTransformer;
 use Gladiator\Events\QueueMessageRequest;
-
 use Gladiator\Models\Message;
 
 class UsersController extends ApiController

--- a/app/Http/Controllers/MessagesController.php
+++ b/app/Http/Controllers/MessagesController.php
@@ -105,8 +105,6 @@ class MessagesController extends Controller
             'test' => request('test'),
         ];
 
-        Log::debug($resources);
-
         // Kick off email sending
         event(new QueueMessageRequest($resources));
 

--- a/app/Http/Controllers/MessagesController.php
+++ b/app/Http/Controllers/MessagesController.php
@@ -105,6 +105,8 @@ class MessagesController extends Controller
             'test' => request('test'),
         ];
 
+        Log::debug($resources);
+
         // Kick off email sending
         event(new QueueMessageRequest($resources));
 

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -70,10 +70,10 @@ class Email
         // @TODO - set defaults?
         $tokens = [
             ':campaign_title:'        => $this->contest->campaign->title,
-            ':end_date:'              => isset($this->competition) ? $this->competition->competition_end_date->format('F d, Y') : '',
+            ':end_date:'              => !is_null($this->competition) ? $this->competition->competition_end_date->format('F d, Y') : '',
             ':first_name:'            => $user->first_name,
-            ':leaderboard_msg_day:'   => isset($this->competition) ? get_day_of_week($this->competition->leaderboard_msg_day) : '',
-            ':leaderboard_msg_day-1:' => isset($this->competition) ? get_day_of_week($this->competition->leaderboard_msg_day - 1) : '',
+            ':leaderboard_msg_day:'   => !is_null($this->competition) ? get_day_of_week($this->competition->leaderboard_msg_day) : '',
+            ':leaderboard_msg_day-1:' => !is_null($this->competition) ? get_day_of_week($this->competition->leaderboard_msg_day - 1) : '',
             ':pro_tip:'               => $this->message->pro_tip,
             ':prove_it_link:'         => url(config('services.phoenix.uri') .'/node/' . $this->contest->campaign_id . '#prove'),
             ':reportback_noun:'       => strtolower($this->contest->campaign->reportback_info->noun),

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -70,10 +70,10 @@ class Email
         // @TODO - set defaults?
         $tokens = [
             ':campaign_title:'        => $this->contest->campaign->title,
-            ':end_date:'              => !is_null($this->competition) ? $this->competition->competition_end_date->format('F d, Y') : '',
+            ':end_date:'              => ! is_null($this->competition) ? $this->competition->competition_end_date->format('F d, Y') : '',
             ':first_name:'            => $user->first_name,
-            ':leaderboard_msg_day:'   => !is_null($this->competition) ? get_day_of_week($this->competition->leaderboard_msg_day) : '',
-            ':leaderboard_msg_day-1:' => !is_null($this->competition) ? get_day_of_week($this->competition->leaderboard_msg_day - 1) : '',
+            ':leaderboard_msg_day:'   => ! is_null($this->competition) ? get_day_of_week($this->competition->leaderboard_msg_day) : '',
+            ':leaderboard_msg_day-1:' => ! is_null($this->competition) ? get_day_of_week($this->competition->leaderboard_msg_day - 1) : '',
             ':pro_tip:'               => $this->message->pro_tip,
             ':prove_it_link:'         => url(config('services.phoenix.uri') .'/node/' . $this->contest->campaign_id . '#prove'),
             ':reportback_noun:'       => strtolower($this->contest->campaign->reportback_info->noun),

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -50,7 +50,7 @@ class Email
     {
         $this->message = $resources['message'];
         $this->contest = $resources['contest'];
-        $this->competition = $resources['competition'];
+        $this->competition = isset($resources['competition']) ? $resources['competition'] : null;
         $this->users = $resources['users'];
 
         $this->manager = app(\Gladiator\Services\Manager::class);

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -70,10 +70,10 @@ class Email
         // @TODO - set defaults?
         $tokens = [
             ':campaign_title:'        => $this->contest->campaign->title,
-            ':end_date:'              => $this->competition->competition_end_date->format('F d, Y'),
+            ':end_date:'              => isset($this->competition) ? $this->competition->competition_end_date->format('F d, Y') : '',
             ':first_name:'            => $user->first_name,
-            ':leaderboard_msg_day:'   => get_day_of_week($this->competition->leaderboard_msg_day),
-            ':leaderboard_msg_day-1:' => get_day_of_week($this->competition->leaderboard_msg_day - 1),
+            ':leaderboard_msg_day:'   => isset($this->competition) ? get_day_of_week($this->competition->leaderboard_msg_day) : '',
+            ':leaderboard_msg_day-1:' => isset($this->competition) ? get_day_of_week($this->competition->leaderboard_msg_day - 1) : '',
             ':pro_tip:'               => $this->message->pro_tip,
             ':prove_it_link:'         => url(config('services.phoenix.uri') .'/node/' . $this->contest->campaign_id . '#prove'),
             ':reportback_noun:'       => strtolower($this->contest->campaign->reportback_info->noun),


### PR DESCRIPTION
#### What's this PR do?
Adds email sending upon user import to gladiator / competition join.

#### How should this be manually tested?
Ive been using Postman with the following details,

```
POST /api/v1/users HTTP/1.1
Host: gladiator.app
Content-Type: application/json
X-DS-Gladiator-API-Key: hah nope.
Accept: application/json
Cache-Control: no-cache
{
    "id": "joe@dosomething.org",
    "term": "email",
    "role": "user",
    "campaign_run_id": "1903",
    "campaign_id": "1485"
}
```

You'll also need to make sure that ^ test user isnt in the user waiting rooms pivot table.

#### Any background context you want to provide?
I had to make some changes to Email because it assumes that a competition has been created. (For welcome emails only the contest exists)

#### What are the relevant tickets?
Fixes #240 