### PR TITLE
Only send checkin "are you alive" messages to people who are slacking.

### DIFF
--- a/app/Http/Controllers/MessagesController.php
+++ b/app/Http/Controllers/MessagesController.php
@@ -97,6 +97,11 @@ class MessagesController extends Controller
 
         $users = $this->manager->getModelUsers($competition, true);
 
+        // Only send checkin messages to users who haven't reported back.
+        if ($message->type === 'checkin') {
+            $users =  $users->where('reportback', null);
+        }
+
         $resources = [
             'message' => $message,
             'contest' => $contest,

--- a/app/Http/Controllers/MessagesController.php
+++ b/app/Http/Controllers/MessagesController.php
@@ -99,7 +99,7 @@ class MessagesController extends Controller
 
         // Only send checkin messages to users who haven't reported back.
         if ($message->type === 'checkin') {
-            $users =  $users->where('reportback', null);
+            $users = $users->where('reportback', null);
         }
 
         $resources = [


### PR DESCRIPTION
#### What's this PR do?
Limit check in message user list to people who have `null` reportbacks

#### How should this be manually tested?
You can do what I did, and right inside of that `if` statement `dd($users)` and check that users have null reportbacks.

#### Any background context you want to provide?
[collections FTW](https://laravel.com/docs/5.1/collections#method-where)

#### What are the relevant tickets?
Fixes #242