### PR TITLE
Makes sure the email is appended

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -69,6 +69,10 @@ class UsersController extends ApiController
             unset($credentials['term']);
 
             $user = $this->registrar->createUser((object) $credentials);
+
+            if ($request->input('term')) {
+                $user->email = $request->input('id');
+            }
         }
 
         $contest = Contest::with(['waitingRoom', 'competitions'])->where('campaign_id', '=', $request['campaign_id'])

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -70,7 +70,7 @@ class UsersController extends ApiController
 
             $user = $this->registrar->createUser((object) $credentials);
 
-            if ($request->input('term') === 'enail') {
+            if ($request->input('term') === 'email') {
                 $user->email = $request->input('id');
             }
         }

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -70,7 +70,7 @@ class UsersController extends ApiController
 
             $user = $this->registrar->createUser((object) $credentials);
 
-            if ($request->input('term')) {
+            if ($request->input('term') === 'enail') {
                 $user->email = $request->input('id');
             }
         }


### PR DESCRIPTION
#### What's this PR do?
Forces the email to be appended to the user obj if the term is email.

#### How should this be manually tested?
Are you sent a welcome email upon joining a competition?

#### Any background context you want to provide?
Due to some funkyness that i dont entirely understand the User obj returned from the repository doesnt have an email on it. So I just forced it to be there so the email can use it.

#### What are the relevant tickets?
Fixes #240 
