### PR TITLE
Wercker should run tests on builds!

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,6 +20,7 @@
     </filter>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="DB_DATABASE" value="gladiator_testing" />
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>

--- a/wercker.yml
+++ b/wercker.yml
@@ -2,10 +2,33 @@ box: blisteringherb/scholarship@0.0.8
 build:
     # The steps that will be executed on build
     steps:
-      # A custom script step, name value is used in the UI
-      # and the code value contains the command that get executed
+      - script:
+          name: Update apt
+          code: sudo apt-get update
+      - script:
+          name: install mysql
+          code: |-
+            export DEBIAN_FRONTEND=noninteractive
+            sudo -E apt-get -q -y install mysql-server
+            mysqladmin -u root password root
+            mysql -u root -proot -e "CREATE USER 'homestead'@'localhost' IDENTIFIED BY 'secret';"
+            mysql -u root -proot -e "GRANT ALL PRIVILEGES ON *.* TO 'homestead'@'localhost' WITH GRANT OPTION;"
+      - script:
+          name: install php extensions
+          code: |-
+            sudo apt-get install php5-mysql
+            sudo apt-get install php5-gd
+      - script:
+          name: Update Composer
+          code: sudo composer self-update
       - leipert/composer-install@0.9.1
       - wercker/bundle-install@1.1.1
+      - script:
+          name: phpunit
+          code: |-
+              cp .env.example .env
+              mysql -u homestead -psecret -e "CREATE DATABASE gladiator_testing;"
+              vendor/bin/phpunit
       - script:
           name: npm install
           code: |-
@@ -13,8 +36,10 @@ build:
             npm config set cache $WERCKER_CACHE_DIR/wercker/npm
             sudo npm install
       - script:
-          name: gulp
-          code: gulp
+          name: build assets
+          code: |-
+            export NODE_ENV=production
+            gulp --production
       - script:
           name: change permissions
           code: sudo chown -R ubuntu:ubuntu ./

--- a/wercker.yml
+++ b/wercker.yml
@@ -37,9 +37,7 @@ build:
             sudo npm install
       - script:
           name: build assets
-          code: |-
-            export NODE_ENV=production
-            gulp --production
+          code: gulp
       - script:
           name: change permissions
           code: sudo chown -R ubuntu:ubuntu ./


### PR DESCRIPTION
#### What's this PR do?
This PR configures Wercker to run the PHPUnit test suite on every build.

#### How should this be manually tested?
Check out that build. 👀 

#### Any background context you want to provide?
This is based on the Wercker config from Voting App and Northstar. Since our "box" doesn't come with MySQL or the PHP MySQL extension installed (like Homestead or our production servers do), we have to manually install it on each build.

#### What are the relevant tickets?
🍃 🚥 