### PR TITLE
Initial User test cases - It takes a village

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\ServiceProvider;
 use Gladiator\Repositories\CacheUserRepository;
 use Gladiator\Repositories\DatabaseUserRepository;
 use Gladiator\Repositories\UserRepositoryContract;
+use Gladiator\Services\Northstar\Northstar;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -27,7 +28,11 @@ class AppServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->bind(UserRepositoryContract::class, function ($app) {
-            return new CacheUserRepository(new DatabaseUserRepository);
+            return new CacheUserRepository(
+                new DatabaseUserRepository(
+                    $app[Northstar::class]
+                )
+            );
         });
     }
 }

--- a/app/Repositories/DatabaseUserRepository.php
+++ b/app/Repositories/DatabaseUserRepository.php
@@ -17,9 +17,9 @@ class DatabaseUserRepository implements UserRepositoryContract
     /**
      * Create new DatabaseUserRepository instance.
      */
-    public function __construct()
+    public function __construct(Northstar $northstar)
     {
-        $this->northstar = new Northstar;
+        $this->northstar = $northstar;
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -50,7 +50,7 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
     /**
      * Mock a class, and register with the IoC container.
      *
-     * @param $class String - Class name to mock
+     * @param  $class  string  Class name to mock
      * @return \Mockery\MockInterface
      */
     public function mock($class)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -27,9 +27,9 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
         $admin = new User();
         $admin->id = str_random(24);
         $admin->role = 'admin';
-        
+
         $this->be($admin);
-        
+
         return $this;
     }
 
@@ -45,5 +45,20 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
         $app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
 
         return $app;
+    }
+
+    /**
+     * Mock a class, and register with the IoC container.
+     *
+     * @param $class String - Class name to mock
+     * @return \Mockery\MockInterface
+     */
+    public function mock($class)
+    {
+        $mock = Mockery::mock($class);
+
+        $this->app->instance($class, $mock);
+
+        return $mock;
     }
 }

--- a/tests/UserApiTest.php
+++ b/tests/UserApiTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Gladiator\Models\User;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+
+class UserApiTest extends TestCase
+{
+    /**
+     * Test for valid response.
+     *
+     * @return void
+     */
+    public function testUserApiReturnsResponse()
+    {
+        $this->json('GET', 'api/v1/users')
+             ->assertResponseStatus('200');
+    }
+
+    /**
+     * Test for retrieving valid users.
+     *
+     * @return void
+     */
+    public function testUserApiReturnsUsers()
+    {
+        $users = factory(User::class, 2)->create();
+
+        $this->json('GET', 'api/v1/users')
+             ->seeJsonStructure([
+                '*' => [
+                    'id', 'created_at', 'updated_at', 'role',
+                ]
+            ]);
+    }
+}

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -1,27 +1,26 @@
 <?php
 
 use Gladiator\Models\User;
+use Gladiator\Services\Northstar\Northstar;
+use Gladiator\Repositories\UserRepositoryContract;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 
 class UserTest extends TestCase
 {
-    protected $repository;
-
     /**
-     * Test to retrieve an existing contestant user in the database.
+     * Test for storing a new contestant user in database using repository.
      *
      * @return void
-     * @test
      */
-    public function itCanStoreANewContestant()
+    public function testStoreNewUserUsingRepository()
     {
         $account = (object) [
             'id' => str_random(24),
         ];
 
-        $repository = app(\Gladiator\Repositories\UserRepositoryContract::class);
+        $repository = app(UserRepositoryContract::class);
         $user = $repository->create($account);
 
         $this->assertTrue($user instanceof User);
@@ -34,96 +33,29 @@ class UserTest extends TestCase
 
 
     /**
-     * Test to retrieve an existing contestant user in the database.
+     * Test to find and retrieve an existing user in the database via
+     * their Northstar ID using repository.
      *
      * @return void
-     * @test
      */
-    public function itRetrievesAnExistingContestantUserByNorthstarId()
+    public function testFindUserByNorthstarIdUsingRepository()
     {
         $model = factory(User::class)->create();
 
-        $mock = $this->mock(\Gladiator\Services\Northstar\Northstar::class)
+        $mock = $this->mock(Northstar::class)
             ->shouldReceive('getUser')
             ->andReturn((object) [
                 'id' => $model->id,
-                'first_name' => 'Larry',
+                'first_name' => 'Kallark',
                 // ...
             ]);
 
-        $repository = app(\Gladiator\Repositories\UserRepositoryContract::class);
-        $user = $repository->find($model->id);
+        $repository = app(UserRepositoryContract::class);
 
+        $user = $repository->find($model->id);
 
         $this->assertEquals($model->id, $user->id);
         $this->assertEquals($model->role, $user->role);
-        $this->assertEquals('Larry', $user->first_name);
-    }
-
-    /**
-     * Test to retrieve an existing contestant user in the database.
-     *
-     * @return void
-     * @test
-     */
-    public function itRetrievesAnExistingAdminUserByNorthstarId()
-    {
-        $account = (object) [
-            'id' => str_random(24),
-            'role' => 'admin',
-        ];
-
-        $repository = app(\Gladiator\Repositories\UserRepositoryContract::class);
-        $repository->create($account);
-
-        $this->seeInDatabase('users', [
-            'id' => $account->id,
-            'role' => 'admin',
-        ]);
-    }
-
-    /**
-     * Test to retrieve an existing user in the database.
-     *
-     * @return void
-     * @test
-     */
-    // public function testUserIsInWaitingRoom()
-    // {
-        // $this->json('POST', 'api/v1/users',
-        //     ['id' => 'fantini-loves-impact@dosomething.org',
-        //      'term', => 'email',
-        //      'campaign_id' => '1',
-        //      'campaign_run_id' => '2'
-        //     ]);
-
-        // $this->assertTrue(true);
-    // }
-
-    /**
-     * Test to see if our api returns json.
-     *
-     * @return void
-     * @test
-     */
-    public function testUserApiReturnsResponse()
-    {
-        $this->json('GET', 'api/v1/users')
-             ->assertResponseStatus('200');
-    }
-
-    /**
-     * Test to see if the api returns valid users.
-     *
-     * @return void
-     * @test
-     */
-    public function testUserApiReturnsUsers()
-    {
-        $users = factory(User::class, 2)->create();
-        $this->json('GET', 'api/v1/users')
-             ->seeJsonStructure(['*' => [
-                     'id', 'created_at', 'updated_at', 'role',
-                 ]]);
+        $this->assertEquals('Kallark', $user->first_name);
     }
 }

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -9,28 +9,76 @@ class UserTest extends TestCase
 {
     protected $repository;
 
-
-    public function setUp()
-    {
-        parent::setUp();
-
-        // $this->repository = app(\Gladiator\Repositories\UserRepositoryContract::class);
-    }
-
     /**
-     * Test to retrieve an existing user in the database.
+     * Test to retrieve an existing contestant user in the database.
      *
      * @return void
      * @test
      */
-    public function itRetrievesAnExistingUserByNorthstarId()
+    public function itCanStoreANewContestant()
     {
-        // dd(get_class($this->repository));
+        $account = (object) [
+            'id' => str_random(24),
+        ];
 
-        // $user = User::create()
+        $repository = app(\Gladiator\Repositories\UserRepositoryContract::class);
+        $user = $repository->create($account);
 
-        // dd($user);
+        $this->assertTrue($user instanceof User);
 
-        $this->assertTrue(true);
+        $this->seeInDatabase('users', [
+            'id' => $account->id,
+            'role' => null,
+        ]);
+    }
+
+
+    /**
+     * Test to retrieve an existing contestant user in the database.
+     *
+     * @return void
+     * @test
+     */
+    public function itRetrievesAnExistingContestantUserByNorthstarId()
+    {
+        $model = factory(User::class)->create();
+
+        $mock = $this->mock(\Gladiator\Services\Northstar\Northstar::class)
+            ->shouldReceive('getUser')
+            ->andReturn((object) [
+                'id' => $model->id,
+                'first_name' => 'Larry',
+                // ...
+            ]);
+
+        $repository = app(\Gladiator\Repositories\UserRepositoryContract::class);
+        $user = $repository->find($model->id);
+
+
+        $this->assertEquals($model->id, $user->id);
+        $this->assertEquals($model->role, $user->role);
+        $this->assertEquals('Larry', $user->first_name);
+    }
+
+    /**
+     * Test to retrieve an existing contestant user in the database.
+     *
+     * @return void
+     * @test
+     */
+    public function itRetrievesAnExistingAdminUserByNorthstarId()
+    {
+        $account = (object) [
+            'id' => str_random(24),
+            'role' => 'admin',
+        ];
+
+        $repository = app(\Gladiator\Repositories\UserRepositoryContract::class);
+        $repository->create($account);
+
+        $this->seeInDatabase('users', [
+            'id' => $account->id,
+            'role' => 'admin',
+        ]);
     }
 }

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Gladiator\Models\User;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+
+class UserTest extends TestCase
+{
+    protected $repository;
+
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        // $this->repository = app(\Gladiator\Repositories\UserRepositoryContract::class);
+    }
+
+    /**
+     * Test to retrieve an existing user in the database.
+     *
+     * @return void
+     * @test
+     */
+    public function itRetrievesAnExistingUserByNorthstarId()
+    {
+        // dd(get_class($this->repository));
+
+        // $user = User::create()
+
+        // dd($user);
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
This PR (with lots of help from @DFurnes) sets up some initial User test cases for Gladiator using the user repository. It also adds the new `mock()` method to the `TestCase` class to help allow the use of mocks when testing.

@angaither also added some User API tests as well to help start getting some API test action in too!

#### How should this be manually tested?
Well, do a `composer dump-autoload` and then run `phpunit`! Any failed tests? Good, there shouldn't be any!

#### Any background context you want to provide?
@angaither I moved the User API tests into their own `UserApiTest` case class. Figured it would help make things easier with test code for User web app vs User API.

#### What are the relevant tickets?
Refs #25

---
@DFurnes  @DoSomething/gladiator