### PR TITLE
Updating waiting room ux/ui and some other fixes.

### DIFF
--- a/app/Http/Controllers/WaitingRoomsController.php
+++ b/app/Http/Controllers/WaitingRoomsController.php
@@ -105,7 +105,7 @@ class WaitingRoomsController extends Controller
     {
         $room->fill($request->all())->save();
 
-        return redirect()->back()->with('status', 'Waiting room has been updated!');
+        return redirect()->route('waitingrooms.show', $room->id)->with('status', 'Waiting room has been updated!');
     }
 
     /**

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -13,7 +13,12 @@ class DatabaseSeeder extends Seeder
     {
         $this->call(ContestTableSeeder::class);
         $this->call(UserTableSeeder::class);
-        $this->call(CompetitionTableSeeder::class);
         $this->call(MessageTableSeeder::class);
+
+        // @TODO: We shouldn't be seeding the Competitions for a Contest without afterwards
+        // handling and removing the users in that respective Contest's WaitingRoom. It
+        // is leading to very confusing data with how the system is intended to work.
+        // Commenting out the seeder for now, until we get a chance to refactor it if needed.
+        // $this->call(CompetitionTableSeeder::class);
     }
 }

--- a/resources/views/competitions/show.blade.php
+++ b/resources/views/competitions/show.blade.php
@@ -10,7 +10,7 @@
     <div class="container">
         <div class="wrapper">
             <div class="container__block -half">
-                <h2 class="heading">Competition information</h1>
+                <h2 class="heading">Information</h1>
 
                 <ul>
                     <li><strong>Campaign:</strong> {{ $contest->campaign->title or 'No title available' }}</li>

--- a/resources/views/waitingrooms/partials/_form_split.blade.php
+++ b/resources/views/waitingrooms/partials/_form_split.blade.php
@@ -1,5 +1,6 @@
 <form method="POST" action="{{ route('split', $room->id) }}">
-    {{ method_field('POST') }}
+    @include('layouts.errors')
+
     {{ csrf_field() }}
 
     <div class="container__block">
@@ -18,9 +19,7 @@
             <input type="text" name="rules_url" id="rules_url" class="text-field" placeholder="http://docs.google.com/the-rules" />
         </div>
 
-        @include('competitions.partials._form_leaderboard_msg_day_field', [
-            'default' => null,
-        ])
+        @include('competitions.partials._form_leaderboard_msg_day_field', [ 'default' => null ])
 
         <input type="submit" class="button" value="Split" />
     </div>

--- a/resources/views/waitingrooms/partials/_form_waitingrooms.blade.php
+++ b/resources/views/waitingrooms/partials/_form_waitingrooms.blade.php
@@ -2,7 +2,7 @@
 
 <div class="form-item -padded">
     {{ Form::label('contest_id', 'Contest ID:', ['class' => 'field-label']) }}
-    {{ Form::text('contest_id', NULL, ['class' => 'text-field']) }}
+    {{ Form::text('contest_id', NULL, ['class' => 'text-field', 'readonly' => 'readonly']) }}
 </div>
 
 <div class="form-item -padded">

--- a/resources/views/waitingrooms/show.blade.php
+++ b/resources/views/waitingrooms/show.blade.php
@@ -9,26 +9,39 @@
 
     <div class="container">
         <div class="wrapper">
-            <div class="container__block">
-                <p>Contest ID: <a href="{{ route('contests.show', $room->contest_id) }}">{{ $room->contest_id }}</a></p>
-                <p>Campaign ID: {{ $contest->campaign_id }}</p>
-                <p>Campaign Run ID: {{ $contest->campaign_run_id }}</p>
-                <p>Signup Start Date: {{ $room->signup_start_date->format('F d, Y') }}</p>
-                <p>Signup End Date: {{ $room->signup_end_date->format('F d, Y') }}</p>
+            <div class="container__block -half">
+                <h2 class="heading">Information</h2>
 
+                <ul>
+                    <li><strong>Campaign ID:</strong> {{ $contest->campaign_id }}</li>
+                    <li><strong>Campaign Run ID:</strong> {{ $contest->campaign_run_id }}</li>
+                    <li><strong>Contest ID:</strong> <a href="{{ route('contests.show', $room->contest_id) }}">{{ $room->contest_id }}</a></li>
+                    <li><strong>Signup Start Date:</strong> {{ $room->signup_start_date->format('F d, Y') }}</li>
+                    <li><strong>Signup End Date:</strong> {{ $room->signup_end_date->format('F d, Y') }}</li>
+                </ul>
+            </div>
+            <div class="container__block -half">
                 <ul class="form-actions -inline">
+                    <li>
+                        <a href="{{ route('waitingrooms.edit', $room->id) }}" class="button">Edit</a>
+                    </li>
                     @if (has_signup_period_ended($room->signup_end_date))
                         <li>
                             <a href="{{ route('split', $room->id) }}" class="button -secondary">Split room</a>
                         </li>
                     @endif
+                </ul>
+            </div>
 
-                    <li>
-                        <a href="{{ route('waitingrooms.edit', $room->id) }}" class="button">Edit</a>
-                    </li>
-                    <li>
-                        <a href="{{ route('waitingrooms.export', $room->id) }}" class="button">Export</a>
-                    </li>
+        </div>
+    </div>
+
+    <div class="container">
+        <div class="wrapper">
+            <div class="container__block">
+            <h2 class="heading">Data export</h1>
+                <ul class="list">
+                    <li><a href="{{ route('waitingrooms.export', $room->id) }}">&DownArrowBar; Export</a> &mdash; CSV list of users for this waiting room</li>
                 </ul>
             </div>
         </div>

--- a/resources/views/waitingrooms/split.blade.php
+++ b/resources/views/waitingrooms/split.blade.php
@@ -25,7 +25,7 @@
                         <tbody>
                            @foreach($split as $key => $competition)
                                 <tr class="table__row">
-                                    <td class="table__cell">{{ $key }}</td>
+                                    <td class="table__cell">{{ $key + 1 }}</td>
                                     <td class="table__cell">{{ count($competition) }}</td>
                                 </tr>
                             @endforeach


### PR DESCRIPTION
#### What's this PR do?
This PR updates a few of the WaitingRoom views to use similar UX/UI as other resource views in Gladiator. It adds missing errors for the waiting room split page and also includes a few other fixes and code cleanup.

This also comments out the Competitions Seeder because during the seeding process, we're not properly handling how the system typically creates Competitions, where they are created based on a set of users in a WaitingRoom and then once the Competition is created, the WaitingRoom is cleared. Instead, in the seeder, we just create some random, empty Competitions in the first Contest and that's it. This was throwing off data when working on Competition user count info, etc.

#### How should this be manually tested?
Make sure the WaitingRoom related forms all work!

#### What are the relevant tickets?
Fixes #258

---
@DoSomething/gladiator 
