### PR TITLE
Update test emails and refactor

### DIFF
--- a/app/Http/Controllers/CompetitionsController.php
+++ b/app/Http/Controllers/CompetitionsController.php
@@ -163,6 +163,18 @@ class CompetitionsController extends Controller
      */
     public function message(Competition $competition, Contest $contest)
     {
+        $key = generate_model_flash_session_key($competition, ['includeActivity' => true]);
+
+        if (session()->has($key)) {
+            $competition = session($key);
+
+            session()->reflash();
+        } else {
+            $competition = $this->manager->getCompetitionOverview($competition, true);
+
+            session()->flash($key, $competition);
+        }
+
         $messages = Message::where('contest_id', '=', $contest->id)->get();
 
         return view('messages.show', compact('messages', 'competition'));

--- a/app/Http/Controllers/MessagesController.php
+++ b/app/Http/Controllers/MessagesController.php
@@ -10,7 +10,7 @@ use Gladiator\Events\QueueMessageRequest;
 use Gladiator\Repositories\MessageRepository;
 use Gladiator\Repositories\UserRepositoryContract;
 use Gladiator\Services\Manager;
-use Gladiator\Services\Registrar;
+use Auth;
 
 class MessagesController extends Controller
 {
@@ -29,16 +29,9 @@ class MessagesController extends Controller
     protected $userRepository;
 
     /**
-     * Registrar instance.
-     *
-     * @var \Gladiator\Services\Registrar;
-     */
-    protected $registrar;
-
-    /**
      * Create new MessagesController instance.
      */
-    public function __construct(MessageRepository $msgRepository, UserRepositoryContract $userRepository, Manager $manager, Registrar $registrar)
+    public function __construct(MessageRepository $msgRepository, UserRepositoryContract $userRepository, Manager $manager)
     {
         $this->manager = $manager;
         $this->msgRepository = $msgRepository;
@@ -46,8 +39,6 @@ class MessagesController extends Controller
 
         $this->middleware('auth');
         $this->middleware('role:admin,staff');
-
-        $this->registrar = $registrar;
     }
 
     /**
@@ -105,9 +96,10 @@ class MessagesController extends Controller
         $contest = Contest::find($contestId);
         $contest = $this->manager->appendCampaign($contest);
 
-        // @TODO - Move into it's own function.
         if (request('test')) {
-            $user = $this->registrar->findNorthstarAccount('email', $contest->sender_email);
+            $user = Auth::user();
+            $user = $this->userRepository->find($user->id);
+            $user = $this->manager->appendReportback($user, null);
 
             $users = [$user];
         } else {

--- a/app/Http/Controllers/MessagesController.php
+++ b/app/Http/Controllers/MessagesController.php
@@ -90,23 +90,18 @@ class MessagesController extends Controller
      */
     public function sendMessage(Message $message)
     {
-        // Get contest.
-        $contestId = request('contest_id');
-        $contest = Contest::find($contestId);
-        $contest = $this->manager->appendCampaign($contest);
-
         // Get competition with activity.
         $competitionId = request('competition_id');
         $competition = Competition::find($competitionId);
 
-        // Get competition with activity from flash if it is there, otherwise
-        // grab it.
+        // Get competition with activity from flash if it is there.
+        // Otherwise, grab it.
         $key = generate_model_flash_session_key($competition, ['includeActivity' => true]);
 
         if (session()->has($key)) {
             $competition = session($key);
         } else {
-            $competition = $this->manager->getCompetitionOverview($competition, $withReportback);
+            $competition = $this->manager->getCompetitionOverview($competition, true);
         }
 
         // Send test emails to authenticated user.
@@ -127,7 +122,6 @@ class MessagesController extends Controller
 
         $resources = [
             'message' => $message,
-            'contest' => $contest,
             'competition' => $competition,
             'users' => $users,
             'test' => request('test'),
@@ -136,6 +130,6 @@ class MessagesController extends Controller
         // Kick off email sending
         event(new QueueMessageRequest($resources));
 
-        return redirect()->route('competitions.message', ['competition' => $competitionId, 'contest' => $contestId])->with('status', 'Fired that right the hell off!');
+        return redirect()->route('competitions.message', ['competition' => $competitionId, 'contest' => request('contest_id')])->with('status', 'Fired that right the hell off!');
     }
 }

--- a/app/Http/Controllers/MessagesController.php
+++ b/app/Http/Controllers/MessagesController.php
@@ -98,7 +98,16 @@ class MessagesController extends Controller
         // Get competition with activity.
         $competitionId = request('competition_id');
         $competition = Competition::find($competitionId);
-        $competition = $this->manager->getCompetitionOverview($competition, true);
+
+        // Get competition with activity from flash if it is there, otherwise
+        // grab it.
+        $key = generate_model_flash_session_key($competition, ['includeActivity' => true]);
+
+        if (session()->has($key)) {
+            $competition = session($key);
+        } else {
+            $competition = $this->manager->getCompetitionOverview($competition, $withReportback);
+        }
 
         // Send test emails to authenticated user.
         if (request('test')) {

--- a/app/Http/Controllers/MessagesController.php
+++ b/app/Http/Controllers/MessagesController.php
@@ -90,12 +90,17 @@ class MessagesController extends Controller
      */
     public function sendMessage(Message $message)
     {
+        // Get contest.
         $contestId = request('contest_id');
-        $competitionId = request('competition_id');
-        $competition = Competition::find($competitionId);
         $contest = Contest::find($contestId);
         $contest = $this->manager->appendCampaign($contest);
 
+        // Get competition with activity.
+        $competitionId = request('competition_id');
+        $competition = Competition::find($competitionId);
+        $competition = $this->manager->getCompetitionOverview($competition, true);
+
+        // Send test emails to authenticated user.
         if (request('test')) {
             $user = Auth::user();
             $user = $this->userRepository->find($user->id);
@@ -103,7 +108,7 @@ class MessagesController extends Controller
 
             $users = [$user];
         } else {
-            $users = $this->manager->getModelUsers($competition, true);
+            $users = $competition->contestants;
 
             // Only send checkin messages to users who haven't reported back.
             if ($message->type === 'checkin') {

--- a/app/Listeners/QueueMessage.php
+++ b/app/Listeners/QueueMessage.php
@@ -35,30 +35,16 @@ class QueueMessage implements ShouldQueue
         // Build the email.
         $email = new Email($resources);
 
-        if ($resources['test']) {
-            // @TODO - Clean this up. If this is a test email, the Email class should deal
-            // with building one message that can be sent to the admin.
+        foreach ($email->allMessages as $content) {
             $settings = [
-                'subject' => $email->allMessages[0]['message']['subject'],
+                'subject' => $content['message']['subject'],
                 'from' => $email->contest->sender_email,
                 'from_name' => $email->contest->sender_name,
-                'to' => $email->contest->sender_email,
-                'to_name' => $email->contest->sender_name,
+                'to' => $content['user']->email,
+                'to_name' => $content['user']->first_name,
             ];
 
-            $this->sendMail($email->allMessages[0]['message'], $settings);
-        } else {
-            foreach ($email->allMessages as $content) {
-                $settings = [
-                    'subject' => $content['message']['subject'],
-                    'from' => $email->contest->sender_email,
-                    'from_name' => $email->contest->sender_name,
-                    'to' => $content['user']->email,
-                    'to_name' => $content['user']->first_name,
-                ];
-
-                $this->sendMail($content['message'], $settings);
-            }
+            $this->sendMail($content['message'], $settings);
         }
     }
 

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -131,6 +131,16 @@ class Email
     }
 
     /**
+     * Check that the email is valid.
+     *
+     * @param  string $email
+     */
+    protected function validEmail($email)
+    {
+        return filter_var($email, FILTER_VALIDATE_EMAIL);
+    }
+
+    /**
      * Builds the email array.
      */
     protected function setupEmail()
@@ -141,15 +151,17 @@ class Email
 
         // Each user gets it's own processed message
         foreach ($this->users as $key => $user) {
-            $this->allMessages[$key]['user'] = $user;
+            if ($user->email && $this->validEmail($user->email)) {
+                $this->allMessages[$key]['user'] = $user;
 
-            $tokens = $this->defineTokens($user);
+                $tokens = $this->defineTokens($user);
 
-            $processedMessage = $this->processMessage($tokens, $this->message);
+                $processedMessage = $this->processMessage($tokens, $this->message);
 
-            $message = isset($leaderboardVars) ? array_merge($processedMessage, $leaderboardVars) : $processedMessage;
+                $message = isset($leaderboardVars) ? array_merge($processedMessage, $leaderboardVars) : $processedMessage;
 
-            $this->allMessages[$key]['message'] = $message;
+                $this->allMessages[$key]['message'] = $message;
+            }
         }
     }
 

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -159,7 +159,8 @@ class Email
      * Sets the variables needed for leaderboard emails
      * including the full leaderboard and the top three reportbacks.
      *
-     * @param  array $users
+     * @param   array $users
+     * @return  array $vars
      */
     protected function getLeaderboardVars($users)
     {
@@ -180,6 +181,12 @@ class Email
         return $vars;
     }
 
+    /*
+     * Gets the featured reportback and grabs the properties that
+     * email template needs for display.
+     *
+     * @return  array $featuredReportback
+     */
     protected function getFeaturedReportback()
     {
         if (isset($this->message->reportback_id) && isset($this->message->reportback_item_id)) {

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -161,7 +161,10 @@ class Email
     protected function getLeaderboardVars($users)
     {
         if ($this->message->type === 'leaderboard') {
-            $list = $this->manager->catalogUsers($users);
+            $contestants = $this->manager->getModelUsers($this->competition, true);
+
+            $list = $this->manager->catalogUsers($contestants);
+
             $leaderboard = $list['active'];
 
             $vars = [];

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -143,13 +143,9 @@ class Email
 
             $tokens = $this->defineTokens($user);
 
-            $message = [];
+            $processedMessage = $this->processMessage($tokens, $this->message);
 
-            $message = $this->processMessage($tokens, $this->message);
-
-            if ($this->message->type === 'leaderboard') {
-                $message = array_merge($message, $leaderboardVars);
-            }
+            $message = $leaderboardVars ? array_merge($processedMessage, $leaderboardVars) : $processedMessage;
 
             $this->allMessages[$key]['message'] = $message;
         }
@@ -164,21 +160,25 @@ class Email
      */
     protected function getLeaderboardVars($users)
     {
-        $list = $this->manager->catalogUsers($users);
-        $leaderboard = $list['active'];
+        if ($this->message->type === 'leaderboard') {
+            $list = $this->manager->catalogUsers($users);
+            $leaderboard = $list['active'];
 
-        $vars = [];
+            $vars = [];
 
-        if ($leaderboard) {
-            $vars = [
-                'leaderboard' => $leaderboard,
-                'topThree' => $this->manager->getTopThreeReportbacks($leaderboard),
-                'reportbackInfo' => $this->contest->campaign->reportback_info,
-                'featuredReportback' => $this->getFeaturedReportback(),
-            ];
+            if ($leaderboard) {
+                $vars = [
+                    'leaderboard' => $leaderboard,
+                    'topThree' => $this->manager->getTopThreeReportbacks($leaderboard),
+                    'reportbackInfo' => $this->contest->campaign->reportback_info,
+                    'featuredReportback' => $this->getFeaturedReportback(),
+                ];
+            }
+
+            return $vars;
         }
 
-        return $vars;
+        return null;
     }
 
     /*

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -145,7 +145,7 @@ class Email
 
             $processedMessage = $this->processMessage($tokens, $this->message);
 
-            $message = $leaderboardVars ? array_merge($processedMessage, $leaderboardVars) : $processedMessage;
+            $message = isset($leaderboardVars) ? array_merge($processedMessage, $leaderboardVars) : $processedMessage;
 
             $this->allMessages[$key]['message'] = $message;
         }
@@ -160,28 +160,24 @@ class Email
      */
     protected function getLeaderboardVars($users)
     {
-        if ($this->message->type === 'leaderboard') {
-            $contestants = $this->manager->getModelUsers($this->competition, true);
+        $contestants = $this->manager->getModelUsers($this->competition, true);
 
-            $list = $this->manager->catalogUsers($contestants);
+        $list = $this->manager->catalogUsers($contestants);
 
-            $leaderboard = $list['active'];
+        $leaderboard = $list['active'];
 
-            $vars = [];
+        $vars = [];
 
-            if ($leaderboard) {
-                $vars = [
-                    'leaderboard' => $leaderboard,
-                    'topThree' => $this->manager->getTopThreeReportbacks($leaderboard),
-                    'reportbackInfo' => $this->contest->campaign->reportback_info,
-                    'featuredReportback' => $this->getFeaturedReportback(),
-                ];
-            }
-
-            return $vars;
+        if ($leaderboard) {
+            $vars = [
+                'leaderboard' => $leaderboard,
+                'topThree' => $this->manager->getTopThreeReportbacks($leaderboard),
+                'reportbackInfo' => $this->contest->campaign->reportback_info,
+                'featuredReportback' => $this->getFeaturedReportback(),
+            ];
         }
 
-        return null;
+        return $vars;
     }
 
     /*

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -49,8 +49,11 @@ class Email
     public function __construct($resources)
     {
         $this->message = $resources['message'];
-        $this->contest = $resources['contest'];
         $this->competition = isset($resources['competition']) ? $resources['competition'] : null;
+
+        // If a contest is passed in the resources used that, otherwise grab it from the competition.
+        $this->contest = isset($resources['contest']) ? $resources['contest'] : $this->competition->contest;
+
         $this->users = $resources['users'];
         $this->manager = app(\Gladiator\Services\Manager::class);
 

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -52,7 +52,6 @@ class Email
         $this->contest = $resources['contest'];
         $this->competition = isset($resources['competition']) ? $resources['competition'] : null;
         $this->users = $resources['users'];
-
         $this->manager = app(\Gladiator\Services\Manager::class);
 
         $this->setupEmail();
@@ -160,11 +159,7 @@ class Email
      */
     protected function getLeaderboardVars($users)
     {
-        $contestants = $this->manager->getModelUsers($this->competition, true);
-
-        $list = $this->manager->catalogUsers($contestants);
-
-        $leaderboard = $list['active'];
+        $leaderboard = $this->competition->activity['active'];
 
         $vars = [];
 


### PR DESCRIPTION
#### What's this PR do?

Refactors how I was handling test. Now, if it is a test email, we set the `users` resource to be the authenticated user..so only one messaged is processed and that messaged is processed with the admins information. Before, we were using the contest `sender_email` which 1) that might not be a real northstar account and 2) meant we had to still process messages for all users and pick on to send to the `sender_email`. This is better and fast.

Also cleaned up some code, added comments were I had missed it. 

#### What are the relevant tickets?
Fixes #274 