### PR TITLE
Competition data exposure

### DIFF
--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -266,8 +266,11 @@ class Manager
         $statistics['totalContestants'] = count($competition->contestants);
         $statistics['totalReportbacks'] = count($competition->activity['active']);
         $statistics['reportbackRate'] = intval(round(($statistics['totalReportbacks'] / $statistics['totalContestants']) * 100));
+        $statistics['impactQuantity'] = 0;
 
-        //@TODO: Need to collect non-flagged impact quantity.
+        foreach ($competition->activity['active'] as $user) {
+            $statistics['impactQuantity'] += intval($user->reportback->quantity);
+        }
 
         return (object) $statistics;
     }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -73,7 +73,7 @@ function format_date_form_field($model, $field, $defaut = 'MM/DD/YYYY')
 }
 
 /**
- * Formate a timestamp using Carbon for display in a view.
+ * Format a timestamp using Carbon for display in a view.
  *
  * @param  string  $timestamp
  * @return /Carbon/Carbon
@@ -81,6 +81,28 @@ function format_date_form_field($model, $field, $defaut = 'MM/DD/YYYY')
 function format_timestamp_for_display($timestamp)
 {
     return (new Carbon($timestamp))->format('Y-m-d');
+}
+
+/**
+ * Generate a unique key for flashing model data to the session.
+ *
+ * @param  \Illuminate\Database\Eloquent\Model  $model
+ * @param  array  $options
+ * @return string
+ */
+function generate_model_flash_session_key($model, $options = [])
+{
+    if ($model instanceof \Gladiator\Models\Competition) {
+        $key = 'contest_' . $model->contest_id . '-' . 'competition_' . $model->id;
+
+        if (isset($options['includeActivity']) && $options['includeActivity']) {
+            $key .= '-activity_included';
+        }
+
+        return $key;
+    }
+
+    return '';
 }
 
 /**

--- a/resources/views/competitions/show.blade.php
+++ b/resources/views/competitions/show.blade.php
@@ -39,13 +39,13 @@
 
     <div class="container">
         <div class="wrapper">
-            <div class="container__block -half">
+            <div class="container__block">
                 <h2 class="heading">Statistics</h2>
                 <ul class="list">
                     <li>Total number of contestants in competition: <strong>{{ $statistics->totalContestants }}</strong></li>
                     <li>Number of contestants who have reported back: <strong>{{ $statistics->totalReportbacks }}</strong></li>
                     <li>Reportback rate: <strong>{{ $statistics->reportbackRate . '%' }}</strong></li>
-                    <li>Approved reportbacks impact quantity: <strong>{{ $statistics->impactQuantity }} </strong></li>
+                    <li>Approved reportbacks impact quantity: <strong>{{ number_format($statistics->impactQuantity) . ' ' . $competition->contest->campaign->reportback_info->noun . ' ' . $competition->contest->campaign->reportback_info->verb }} </strong></li>
                 </ul>
             </div>
         </div>

--- a/resources/views/competitions/show.blade.php
+++ b/resources/views/competitions/show.blade.php
@@ -42,9 +42,10 @@
             <div class="container__block -half">
                 <h2 class="heading">Statistics</h2>
                 <ul class="list">
-                    <li>Total number of contestants in competition: {{ $statistics->totalContestants }}</li>
-                    <li>Number of contestants who have reported back: {{ $statistics->totalReportbacks }}</li>
-                    <li>Reportback rate: {{ $statistics->reportbackRate . '%' }}</li>
+                    <li>Total number of contestants in competition: <strong>{{ $statistics->totalContestants }}</strong></li>
+                    <li>Number of contestants who have reported back: <strong>{{ $statistics->totalReportbacks }}</strong></li>
+                    <li>Reportback rate: <strong>{{ $statistics->reportbackRate . '%' }}</strong></li>
+                    <li>Approved reportbacks impact quantity: <strong>{{ $statistics->impactQuantity }} </strong></li>
                 </ul>
             </div>
         </div>

--- a/resources/views/competitions/show.blade.php
+++ b/resources/views/competitions/show.blade.php
@@ -10,11 +10,11 @@
     <div class="container">
         <div class="wrapper">
             <div class="container__block -half">
-                <h2 class="heading">Information</h1>
+                <h2 class="heading">Information</h2>
 
                 <ul>
-                    <li><strong>Campaign:</strong> {{ $contest->campaign->title or 'No title available' }}</li>
-                    <li><strong>Campaign Run ID:</strong> {{ $contest->campaign_run_id }}</li>
+                    <li><strong>Campaign:</strong> {{ $competition->contest->campaign->title or 'No title available' }}</li>
+                    <li><strong>Campaign Run ID:</strong> {{ $competition->contest->campaign_run_id }}</li>
                     <li><strong>Contest ID:</strong> <a href="{{ route('contests.show', $competition->contest_id) }}">{{ $competition->contest_id }}</a></li>
                     <li><strong>Start Date:</strong> {{ $competition->competition_start_date->format('F d, Y') }}</li>
                     <li><strong>End Date:</strong> {{ $competition->competition_end_date->format('F d, Y') }}</li>
@@ -27,7 +27,7 @@
                         <a href="{{ route('competitions.edit', $competition->id) }}" class="button">Edit</a>
                     </li>
                     <li>
-                        <a href="{{ route('competitions.message', ['competition' => $competition->id,'contest' => $contest->id]) }}" class="button">Email</a>
+                        <a href="{{ route('competitions.message', ['competition' => $competition->id,'contest' => $competition->contest->id]) }}" class="button">Email</a>
                     </li>
                     <li>
                         <a href="{{ route('competitions.leaderboard', ['competition' => $competition->id]) }}" class="button">Leaderboard</a>
@@ -36,6 +36,20 @@
             </div>
         </div>
     </div>
+
+    <div class="container">
+        <div class="wrapper">
+            <div class="container__block -half">
+                <h2 class="heading">Statistics</h2>
+                <ul class="list">
+                    <li>Total number of contestants in competition: {{ $statistics->totalContestants }}</li>
+                    <li>Number of contestants who have reported back: {{ $statistics->totalReportbacks }}</li>
+                    <li>Reportback rate: {{ $statistics->reportbackRate . '%' }}</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
 
     <div class="container">
         <div class="wrapper">
@@ -48,5 +62,7 @@
         </div>
     </div>
 
-    @include('users.partials._table_users', ['users' => $users, 'role' => 'Contestants: ' . $competition->users->count()])
+
+    @include('users.partials._table_users', ['users' => $competition->contestants, 'role' => 'Contestants: ' . $competition->contestants->count()])
+
 @stop


### PR DESCRIPTION
#### What's this PR do?
This PR updates the Competition show page to include a bunch of statistics for the competition. It also does some behind the scenes magic to keep the data snappy by flashing the session and re-flashing the session as needed so that viewing the leaderboard and exporting it aren't slow when including all the stats in the competition page.

![image](https://cloud.githubusercontent.com/assets/105849/14901853/979741bc-0d65-11e6-8074-5c2715c62c72.png)

#### How should this be manually tested?
Load up the Competition show page and see if all works ok, the new "Statistics" section appears and the viewing the Leaderboard and exporting it are still fast.

#### What are the relevant tickets?
Fixes #189

---
@DoSomething/gladiator @DFurnes 