### PR TITLE
Retroactivly add peeps

### DIFF
--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -169,9 +169,9 @@ class ContestsController extends Controller
 
         // Add the user to a competition or waiting room, but only if not already in it.
         if ($request->has('competition_id')) {
-            $this->manager->addUserToRoom('competitions', $request->competition_id, $user);
+            $this->manager->addUserToModel('competitions', $request->competition_id, $user);
         } else {
-            $this->manager->addUserToRoom('waitingrooms', $request->waitingroom_id, $user);
+            $this->manager->addUserToModel('waitingrooms', $request->waitingroom_id, $user);
         }
 
         return redirect()->route('contests.show', $contest->id)->with('status', 'Allllllright, we added that late punk!');

--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -167,10 +167,10 @@ class ContestsController extends Controller
         }
 
         // Add the user to a competition or waiting room, but only if not already in it.
-        if ($request->has('competition_id') && ! $user->competitions()->where('id', $request->competition_id)->first()) {
-            $user->competitions()->attach($request->competition_id);
-        } elseif ($request->has('waitingroom_id') && ! $user->waitingrooms()->where('id', $request->waitingroom_id)->first()) {
-            $user->waitingRooms()->attach($request->waitingroom_id);
+        if ($request->has('competition_id')) {
+            $this->manager->addUserToRoom('competitions', $request->competition_id, $user);
+        } else {
+            $this->manager->addUserToRoom('waitingrooms', $request->waitingroom_id, $user);
         }
 
         return redirect()->route('contests.show', 1)->with('status', 'Allllllright, we added that late punk!');

--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -155,10 +155,11 @@ class ContestsController extends Controller
     /**
      * The post request to add a user retroactively.
      *
+     * @param  \Gladiator\Models\Contest $contest
      * @param  SignupUserRequest $request
      * @return \Illuminate\Http\Response
      */
-    public function signupUser(SignupUserRequest $request)
+    public function signupUser(Contest $contest, SignupUserRequest $request)
     {
         $user = $this->registrar->findUserAccount($request->all());
 
@@ -173,6 +174,6 @@ class ContestsController extends Controller
             $this->manager->addUserToRoom('waitingrooms', $request->waitingroom_id, $user);
         }
 
-        return redirect()->route('contests.show', 1)->with('status', 'Allllllright, we added that late punk!');
+        return redirect()->route('contests.show', $contest->id)->with('status', 'Allllllright, we added that late punk!');
     }
 }

--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -158,10 +158,10 @@ class ContestsController extends Controller
             $user = $this->registrar->createUser($user);
         }
 
-        // @TODO: only create row if it doesn't exist.
-        if ($request->has('competition_id')) {
+        // Add the user to a competition or waiting room, but only if not already in it.
+        if ($request->has('competition_id') && ! $user->competitions()->where('id', $request->competition_id)->first()) {
             $user->competitions()->attach($request->competition_id);
-        } else {
+        } elseif ($request->has('waitingroom_id') && ! $user->waitingrooms()->where('id', $request->waitingroom_id)->first()) {
             $user->waitingRooms()->attach($request->waitingroom_id);
         }
 

--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -140,6 +140,9 @@ class ContestsController extends Controller
     }
 
     /**
+     *
+     * Grab the form to add a user retroactively.
+     *
      * @param  \Gladiator\Models\Contest $contest
      * @return  \Illuminate\Http\Response
      */
@@ -150,6 +153,13 @@ class ContestsController extends Controller
         return view('contests.signup', compact('contest'));
     }
 
+    /**
+     *
+     * The post request to add a user retroactively.
+     *
+     * @param  SignupUserRequest $request
+     * @return \Illuminate\Http\Response
+     */
     public function signupUser(SignupUserRequest $request)
     {
         $user = $this->registrar->findUserAccount($request->all());

--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -140,7 +140,6 @@ class ContestsController extends Controller
     }
 
     /**
-     *
      * Grab the form to add a user retroactively.
      *
      * @param  \Gladiator\Models\Contest $contest
@@ -154,7 +153,6 @@ class ContestsController extends Controller
     }
 
     /**
-     *
      * The post request to add a user retroactively.
      *
      * @param  SignupUserRequest $request

--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -134,4 +134,20 @@ class ContestsController extends Controller
         $csv = $contest->getCSVExport();
         $csv->output('contest' . $contest->id . '.csv');
     }
+
+    /**
+     * @param  \Gladiator\Models\Contest $contest
+     * @return  \Illuminate\Http\Response
+     */
+    public function signupForm(Contest $contest)
+    {
+        $contest = $contest->load(['waitingroom', 'competitions']);
+
+        return view('contests.signup', compact('contest'));
+    }
+
+    public function signupUser(Contest $contest)
+    {
+        // do things, like signup the user.
+    }
 }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -34,6 +34,9 @@ Route::group(['middleware' => ['web']], function () {
     Route::model('contests', 'Gladiator\Models\Contest');
     Route::get('contests/{contest}/export', 'ContestsController@export')->name('contests.export');
     Route::get('/contests/{id}/messages/edit', 'MessagesController@edit')->name('contests.messages.edit');
+    Route::get('contests/{contest}/signup', 'ContestsController@signupForm')->name('contests.user.add');
+    Route::post('contests/{contest}/signup', 'ContestsController@signupUser')->name('contests.user.add');
+
     Route::match(['put', 'patch'], '/contests/{id}/messages', 'MessagesController@update')->name('contests.messages.update');
     Route::resource('contests', 'ContestsController');
 

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -427,11 +427,11 @@ class Manager
      * @param object $user
      * @return bool
      */
-    public function addUserToRoom($type, $id, $user)
+    public function addUserToModel($model, $id, $user)
     {
         // Attach the user to the room, if it isn't alredy.
-        if (! $user->{$type}()->where('id', $id)->first()) {
-            $user->{$type}()->attach($id);
+        if (! $user->{$model}()->where('id', $id)->first()) {
+            $user->{$model}()->attach($id);
         }
 
         return true;

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -433,6 +433,7 @@ class Manager
         if (! $user->{$type}()->where('id', $id)->first()) {
             $user->{$type}()->attach($id);
         }
+
         return true;
     }
 }

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -418,4 +418,21 @@ class Manager
         // Find the matching reportback item, and return the item.
         return $reportback_items->get($reportback_item_id);
     }
+
+    /**
+     * Attach a user object to a waiting room or a competition.
+     *
+     * @param string $type
+     * @param string $id
+     * @param object $user
+     * @return bool
+     */
+    public function addUserToRoom($type, $id, $user)
+    {
+        // Attach the user to the room, if it isn't alredy.
+        if (! $user->{$type}()->where('id', $id)->first()) {
+            $user->{$type}()->attach($id);
+        }
+        return true;
+    }
 }

--- a/resources/views/contests/show.blade.php
+++ b/resources/views/contests/show.blade.php
@@ -25,11 +25,19 @@
                         <a href="{{ route('contests.export', $contest->id) }}" class="button -secondary">Export</a>
                     </li>
                     <li>
-                        <a href="{{ route('split', $contest->waitingRoom->id) }}" class="button -secondary">Split</a>
+                        <a href="{{ route('contests.user.add', $contest->id) }}" class="button">Signup User</a>
                     </li>
-                    <li>
-                        <a href="{{ route('contests.user.add', $contest->id) }}" class="button -secondary">+ User</a>
-                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <div class="container">
+        <div class="wrapper">
+            <div class="container__block">
+            <h2 class="heading">Data export</h1>
+                <ul class="list">
+                    <li><a href="{{ route('contests.export', $contest->id) }}">&DownArrowBar; Export</a> &mdash; CSV list of users for this contest</li>
                 </ul>
             </div>
         </div>

--- a/resources/views/contests/show.blade.php
+++ b/resources/views/contests/show.blade.php
@@ -19,10 +19,10 @@
             <div class="container__block -half">
                 <ul class="form-actions -inline">
                     <li>
-                        <a href="{{ route('contests.edit', $contest->id) }}" class="button -secondary">Edit</a>
+                        <a href="{{ route('contests.edit', $contest->id) }}" class="button">Edit</a>
                     </li>
                     <li>
-                        <a href="{{ route('contests.export', $contest->id) }}" class="button -secondary">Export</a>
+                        <a href="{{ route('split', $contest->waitingRoom->id) }}" class="button">Split</a>
                     </li>
                     <li>
                         <a href="{{ route('contests.user.add', $contest->id) }}" class="button">Signup User</a>

--- a/resources/views/contests/show.blade.php
+++ b/resources/views/contests/show.blade.php
@@ -27,6 +27,9 @@
                     <li>
                         <a href="{{ route('split', $contest->waitingRoom->id) }}" class="button -secondary">Split</a>
                     </li>
+                    <li>
+                        <a href="{{ route('contests.user.add', $contest->id) }}" class="button -secondary">+ User</a>
+                    </li>
                 </ul>
             </div>
         </div>

--- a/resources/views/contests/signup.blade.php
+++ b/resources/views/contests/signup.blade.php
@@ -10,6 +10,7 @@
     <div class="container">
         <div class="wrapper">
             <form method="POST" action="{{ route('contests.user.add', $contest->id) }}">
+                {{ csrf_field() }}
                 <div class="form-item -padded">
                     <label class="field-label" for="id">User identification:</label>
                     <input type="text" name="id" id="id" class="text-field" placeholder="Email, Mobile Phone Number, Northstar ID or Phoenix ID"/>
@@ -36,8 +37,8 @@
                             <label class="field-label" for="id">Waiting Room ID:</label>
                             <div class="select">
                                 <select name="waitingroom_id" id="waitingroom_id">
-                                    <option value="none">None</option>
-                                    <option value="waitingroom">{{ $contest->waitingroom->id }}</option>
+                                    <option value="">None</option>
+                                    <option value="{{ $contest->waitingroom->id }}">{{ $contest->waitingroom->id }}</option>
                                 </select>
                             </div>
                         </div>
@@ -47,10 +48,10 @@
                         <div class="form-item">
                             <label class="field-label" for="id">Competition ID:</label>
                             <div class="select">
-                                <select name="contest_id" id="contest_id">
-                                    <option value="none">None</option>
+                                <select name="competition_id" id="competition_id">
+                                    <option value="">None</option>
                                     @foreach ($contest->competitions as $competition)
-                                    <option value="competition-{{ $competition->id }}">{{ $competition->id }}</option>
+                                        <option value="{{ $competition->id }}">{{ $competition->id }}</option>
                                     @endforeach
                                 </select>
                             </div>

--- a/resources/views/contests/signup.blade.php
+++ b/resources/views/contests/signup.blade.php
@@ -1,0 +1,67 @@
+@extends('layouts.master')
+
+@section('main_content')
+
+    @include('layouts.header',[
+        'title' => 'Add user',
+        'subtitle' => 'Add a user to a competition or watiting room'
+    ])
+
+    <div class="container">
+        <div class="wrapper">
+            <form method="POST" action="{{ route('contests.user.add', $contest->id) }}">
+                <div class="form-item -padded">
+                    <label class="field-label" for="id">User identification:</label>
+                    <input type="text" name="id" id="id" class="text-field" placeholder="Email, Mobile Phone Number, Northstar ID or Phoenix ID"/>
+                </div>
+
+                <div class="form-item -padded">
+                    <label class="field-label" for="term">Select user ID type:</label>
+                    <div class="select">
+                        <select name="term" id="term">
+                            <option value="email" {{! isset($user->id) ? 'selected' : '' }}>Email</option>
+                            <option value="mobile">Mobile Phone Number</option>
+                            <option value="id" {{ isset($user->id) ? 'selected' : '' }}>Northstar ID</option>
+                            <option value="drupal_id">Phoenix ID</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="container__row">
+                    <div class="container__block">
+                        <h3>Make a choice, but make sure it's a good one.</h3>
+                        <p>You can put someone in a waiting room or a competition, but not both.</p>
+                    </div>
+                    <div class="container__block -half">
+                        <div class="form-item">
+                            <label class="field-label" for="id">Waiting Room ID:</label>
+                            <div class="select">
+                                <select name="waitingroom_id" id="waitingroom_id">
+                                    <option value="none">None</option>
+                                    <option value="waitingroom">{{ $contest->waitingroom->id }}</option>
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="container__block -half">
+                        <div class="form-item">
+                            <label class="field-label" for="id">Competition ID:</label>
+                            <div class="select">
+                                <select name="contest_id" id="contest_id">
+                                    <option value="none">None</option>
+                                    @foreach ($contest->competitions as $competition)
+                                    <option value="competition-{{ $competition->id }}">{{ $competition->id }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="container__block">
+                        <input type="submit" class="button" value="Submit" />
+                    </div>
+            </form>
+        </div>
+    </div>
+
+@stop


### PR DESCRIPTION
#### What's this PR do?
- created a `+ user` in the contest view
- allows for a user to be added to an existing waiting room, or a competition
- added a new signup form to add the people in 

#### How should this be manually tested?
pull down, go to any competition, pick `+ user` and see them be added into the fun. 

#### Any background context you want to provide?
I feel like this chunk could be cleaner
```
// Add the user to a competition or waiting room, but only if not already in it.
if ($request->has('competition_id') && ! $user->competitions()->where('id', $request->competition_id)->first()) {
    $user->competitions()->attach($request->competition_id);
} elseif ($request->has('waitingroom_id') && ! $user->waitingrooms()->where('id', $request->waitingroom_id)->first()) {
    $user->waitingRooms()->attach($request->waitingroom_id);
}
```

#### What are the relevant tickets?
Fixes #254 