### PR TITLE
Moves the welcome email testing to the contest page

### DIFF
--- a/app/Http/Controllers/CompetitionsController.php
+++ b/app/Http/Controllers/CompetitionsController.php
@@ -175,7 +175,7 @@ class CompetitionsController extends Controller
             session()->flash($key, $competition);
         }
 
-        $messages = Message::where('contest_id', '=', $competition->contest->id)->get();
+        $messages = Message::where('contest_id', '=', $competition->contest->id)->where('type', '!=', 'welcome')->get();
 
         return view('messages.show', compact('messages', 'competition'));
     }

--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -3,6 +3,7 @@
 namespace Gladiator\Http\Controllers;
 
 use Gladiator\Models\Contest;
+use Gladiator\Models\Message;
 use Gladiator\Services\Manager;
 use Gladiator\Http\Requests\ContestRequest;
 use Gladiator\Repositories\MessageRepository;
@@ -76,10 +77,10 @@ class ContestsController extends Controller
     public function show(Contest $contest)
     {
         $contest = $this->manager->collectContestInfo($contest->id);
-
         $contest = $this->manager->appendCampaign($contest);
+        $welcomeEmail = Message::where('contest_id', '=', $contest->id)->where('type', '=', 'welcome')->firstOrFail();
 
-        return view('contests.show', compact('contest'));
+        return view('contests.show', compact('contest', 'welcomeEmail'));
     }
 
     /**

--- a/app/Http/Controllers/MessagesController.php
+++ b/app/Http/Controllers/MessagesController.php
@@ -134,7 +134,7 @@ class MessagesController extends Controller
         // Kick off email sending
         event(new QueueMessageRequest($resources));
 
-        if (!$competitionId) {
+        if (! $competitionId) {
             return redirect()->back()->with('status', 'Fired that right the hell off!');
         }
 

--- a/app/Http/Controllers/MessagesController.php
+++ b/app/Http/Controllers/MessagesController.php
@@ -92,7 +92,7 @@ class MessagesController extends Controller
     {
         // Get competition with activity.
         $competitionId = request('competition_id');
-        $competition = null;
+        // $competition = null;
 
         if ($competitionId) {
             $competition = Competition::find($competitionId);
@@ -126,7 +126,7 @@ class MessagesController extends Controller
 
         $resources = [
             'message' => $message,
-            'competition' => $competition,
+            'competition' => isset($competition) ? $competition : null,
             'users' => $users,
             'test' => request('test'),
         ];

--- a/app/Http/Controllers/MessagesController.php
+++ b/app/Http/Controllers/MessagesController.php
@@ -92,16 +92,20 @@ class MessagesController extends Controller
     {
         // Get competition with activity.
         $competitionId = request('competition_id');
-        $competition = Competition::find($competitionId);
+        $competition = null;
 
-        // Get competition with activity from flash if it is there.
-        // Otherwise, grab it.
-        $key = generate_model_flash_session_key($competition, ['includeActivity' => true]);
+        if ($competitionId) {
+            $competition = Competition::find($competitionId);
 
-        if (session()->has($key)) {
-            $competition = session($key);
-        } else {
-            $competition = $this->manager->getCompetitionOverview($competition, true);
+            // Get competition with activity from flash if it is there.
+            // Otherwise, grab it.
+            $key = generate_model_flash_session_key($competition, ['includeActivity' => true]);
+
+            if (session()->has($key)) {
+                $competition = session($key);
+            } else {
+                $competition = $this->manager->getCompetitionOverview($competition, true);
+            }
         }
 
         // Send test emails to authenticated user.
@@ -129,6 +133,10 @@ class MessagesController extends Controller
 
         // Kick off email sending
         event(new QueueMessageRequest($resources));
+
+        if (!$competitionId) {
+            return redirect()->back()->with('status', 'Fired that right the hell off!');
+        }
 
         return redirect()->route('competitions.message', ['competition' => $competitionId, 'contest' => request('contest_id')])->with('status', 'Fired that right the hell off!');
     }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -30,7 +30,7 @@ Route::group(['middleware' => ['web']], function () {
     Route::get('competitions/{competitions}/messages/{contest}', 'CompetitionsController@message')->name('competitions.message');
     Route::get('competitions/{competitions}/leaderboard', 'CompetitionsController@leaderboard')->name('competitions.leaderboard');
 
-    // Competitions
+    // Contests
     Route::model('contests', 'Gladiator\Models\Contest');
     Route::get('contests/{contest}/export', 'ContestsController@export')->name('contests.export');
     Route::get('/contests/{id}/messages/edit', 'MessagesController@edit')->name('contests.messages.edit');

--- a/resources/views/contests/show.blade.php
+++ b/resources/views/contests/show.blade.php
@@ -39,6 +39,7 @@
                 <p>The current name of the messages sender is: <em>{{ $contest->sender_name or 'not assigned' }}</em></p>
                 <p>The current email assigned for the messages sender is: <em>{{ $contest->sender_email or 'not assigned' }}</em></p>
                 <p><a href="{{ route('contests.messages.edit', $contest->id) }}" class="button -secondary">View &amp; Edit Messages</a></p>
+                <p><a href="{{ route('messages.send', ['message' => $welcomeEmail->id, 'contest_id' => $welcomeEmail->contest_id, 'test' => true, ]) }}" class="button -secondary">Test welcome message</a></p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
#### What's this PR do?
Moves the welcome email test/send from the normal messages table to the contest page

#### How should this be manually tested?
Can you still send test emails for the welcome message?
Do other emails still send correctly?

#### Any background context you want to provide?
gonna leave PR comments in a sec

#### What are the relevant tickets?
Fixes #241 