### PR TITLE
Email queue bugs

### DIFF
--- a/app/Listeners/QueueMessage.php
+++ b/app/Listeners/QueueMessage.php
@@ -65,7 +65,7 @@ class QueueMessage implements ShouldQueue
                 $msg->from($settings['from'], $settings['from_name']);
 
                 $msg->to($settings['to'], $settings['to_name'])->subject($settings['subject']);
-            } catch(Swift_RfcComplianceException $e) {
+            } catch (Swift_RfcComplianceException $e) {
                 Log::alert('Message failed to send', ['error' => $e]);
             }
         });

--- a/app/Listeners/QueueMessage.php
+++ b/app/Listeners/QueueMessage.php
@@ -35,16 +35,18 @@ class QueueMessage implements ShouldQueue
         // Build the email.
         $email = new Email($resources);
 
-        foreach ($email->allMessages as $content) {
-            $settings = [
-                'subject' => $content['message']['subject'],
-                'from' => $email->contest->sender_email,
-                'from_name' => $email->contest->sender_name,
-                'to' => $content['user']->email,
-                'to_name' => $content['user']->first_name,
-            ];
+        if (isset($email->allMessages)) {
+            foreach ($email->allMessages as $content) {
+                $settings = [
+                    'subject' => $content['message']['subject'],
+                    'from' => $email->contest->sender_email,
+                    'from_name' => $email->contest->sender_name,
+                    'to' => $content['user']->email,
+                    'to_name' => $content['user']->first_name,
+                ];
 
-            $this->sendMail($content['message'], $settings);
+                $this->sendMail($content['message'], $settings);
+            }
         }
     }
 

--- a/app/Listeners/QueueMessage.php
+++ b/app/Listeners/QueueMessage.php
@@ -66,7 +66,7 @@ class QueueMessage implements ShouldQueue
 
                 $msg->to($settings['to'], $settings['to_name'])->subject($settings['subject']);
             } catch(Swift_RfcComplianceException $e) {
-                Log::alert('Message failed to send', ['message_settings' => $settings]);
+                Log::alert('Message failed to send', ['error' => $e]);
             }
         });
     }

--- a/app/Listeners/QueueMessage.php
+++ b/app/Listeners/QueueMessage.php
@@ -2,6 +2,7 @@
 
 namespace Gladiator\Listeners;
 
+use Log;
 use Illuminate\Mail\Mailer;
 use Gladiator\Events\QueueMessageRequest;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -58,10 +59,14 @@ class QueueMessage implements ShouldQueue
      */
     public function sendMail($content, $settings)
     {
-        $this->mail->queue('messages.' . $content['type'], ['content' => $content], function ($msg) use ($settings) {
-            $msg->from($settings['from'], $settings['from_name']);
+        try {
+            $this->mail->queue('messages.' . $content['type'], ['content' => $content], function ($msg) use ($settings) {
+                $msg->from($settings['from'], $settings['from_name']);
 
-            $msg->to($settings['to'], $settings['to_name'])->subject($settings['subject']);
-        });
+                $msg->to($settings['to'], $settings['to_name'])->subject($settings['subject']);
+            });
+        } catch (Exception $e) {
+            Log::alert('Message failed to queue', ['message' => $content]);
+        }
     }
 }

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -2,6 +2,7 @@
 
 namespace Gladiator\Services;
 
+use Log;
 use Gladiator\Models\Contest;
 use Gladiator\Models\Competition;
 use Gladiator\Models\Message;
@@ -162,6 +163,8 @@ class Email
                 $message = isset($leaderboardVars) ? array_merge($processedMessage, $leaderboardVars) : $processedMessage;
 
                 $this->allMessages[$key]['message'] = $message;
+            } else {
+                Log::alert('User email is not valid', ['id' => $user->id, 'email' => $user->email]);
             }
         }
     }


### PR DESCRIPTION
#### What's this PR do?

Fixes some errors we were seeing in the logs when emails were failing. 

* The first issue was that, while we are validating emails and checking that an email exists before processing a message for a user, I was not taking into account a situation like the welcome email, where there is only one user. So, if the email wasn't valid in that case, no message was processed or added to the `allMessages` array, and we were still trying to loop through `allMessages` which was causing an error around that `foreach`. [Now we make sure there are messages before trying to send](https://github.com/DoSomething/gladiator/compare/email-queue-bugs?expand=1#diff-90614d9e91b9ac6b77756a5777299189R40)

* Second issue was around logging. We needed to 1) [log emails that were not valid from our validation](https://github.com/DoSomething/gladiator/compare/email-queue-bugs?expand=1#diff-4f39f258033e5d77d4d966ae87da96c2R166), and 2) log emails when they [fail to send](https://github.com/DoSomething/gladiator/compare/email-queue-bugs?expand=1#diff-90614d9e91b9ac6b77756a5777299189R69)

#### How should this be manually tested?
This will mostly be helpful in prod, however, if you have a competition with users that bad, if you pull down this branch and send to all users you will see messages in the log with useful messages like.

```
[2016-05-03 22:12:33] local.ALERT: User email is not valid {"id":"557775e9a59dbf3b7a8b457b","email":null} 
``` 
#### Any background context you want to provide?

These two additions will one, make sure that the queue and logs don't get clogged up with a bunch of failed attempts, but also allow us to debug the issue better. 

For example, it is odd to me that people are getting welcome emails to email addresses that are not valid cause they should be logged in users in Phoenix at that time, and therefore valid ¯\_(ツ)_/¯

#### What are the relevant tickets?

Addresses #292 