### PR TITLE
Welcome email bugs

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -99,19 +99,33 @@ class UsersController extends ApiController
 
         // Fire off welcome Email
         Log::debug('Gladiator\Http\Controllers\Api\UsersController -- Sending welcome email', ['user' => $user]);
+        $this->sendWelcomeEmail($user, $contest);
 
+        // @TODO: maybe add more detail to response to indicate which room user was added to?
+        return $this->item($user);
+    }
+
+    /**
+     * Fires off the event to send a welcome email to the user.
+     *
+     * @param  Gladiator\Models\User     $user
+     * @param  Gladiator\Models\Contest  $contest
+     */
+    protected function sendWelcomeEmail($user, $contest)
+    {
         $message = Message::where(['contest_id' => $contest->id, 'type' => 'welcome'])->first();
+
+        // Get the full northstar user object to send to.
         $user = $this->repository->find($user->id);
 
         $resources = [
             'message' => $message,
             'contest' => $contest,
+            //@TODO -- fix the Email class so that it doesn't require this property to be sent as an array.
             'users' => [$user],
             'test' => false,
         ];
-        event(new QueueMessageRequest($resources));
 
-        // @TODO: maybe add more detail to response to indicate which room user was added to?
-        return $this->item($user);
+        event(new QueueMessageRequest($resources));
     }
 }

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -98,7 +98,6 @@ class UsersController extends ApiController
         $this->manager->appendCampaign($contest);
 
         // Fire off welcome Email
-        Log::debug('Gladiator\Http\Controllers\Api\UsersController -- Sending welcome email', ['user' => $user]);
         $this->sendWelcomeEmail($user, $contest);
 
         // @TODO: maybe add more detail to response to indicate which room user was added to?
@@ -125,6 +124,8 @@ class UsersController extends ApiController
             'users' => [$user],
             'test' => false,
         ];
+
+        Log::debug('Gladiator\Http\Controllers\Api\UsersController -- Sending welcome email', ['user' => $user]);
 
         event(new QueueMessageRequest($resources));
     }


### PR DESCRIPTION
#### What's this PR do?

Updated the welcome email logic so that it always grabs the full Northstar user before sending. We were seeing issues with depending on `$this->registrar->findUserAccount();` for the user account because if the account already exists in gladiator, it will just return the User object from the DB that doesn't have an email address attached to it. 

Now we pull in the User Repository and use that to grab the user before sending so we make sure we get all the user info. 

#### How should this be manually tested?

⚠️  I don't have a working dev version of phoenix on my local so I wasn't able to test this really haha. But hoping to get this on QA for further debugging.

#### What are the relevant tickets?
Addresses #292 