### PR TITLE
Updated Leaderboard views along with some other and added new partial.

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -23,6 +23,25 @@ $forge-path: "/assets/vendor/forge/assets/";
       background-color: $error-color;
     }
   }
+
+  &.-muted {
+    background: none;
+    color: $med-gray;
+    font-size: $font-small;
+    font-weight: $weight-normal;
+    text-transform: none;
+    border: 0 none;
+
+    &:hover {
+      color: $off-black;
+      background-color: none;
+      text-decoration: underline;
+    }
+
+    &:focus {
+      box-shadow: none;
+    }
+  }
 }
 
 #matchup-flag {

--- a/resources/views/competitions/leaderboard.blade.php
+++ b/resources/views/competitions/leaderboard.blade.php
@@ -3,9 +3,11 @@
 @section('main_content')
 
     @include('layouts.header', [
-        'title' => 'Competitions',
-        'subtitle' => 'Viewing leaderboard for competition ' . $competition->id
+        'title' => 'Leaderboard',
+        'subtitle' => $competition->contest->campaign->title . ' Competition ID: ' . $competition->id
     ])
+
+    @include('layouts.back', ['link' => ['path' => route('competitions.show', $competition->id), 'copy' => 'back to competition']])
 
     <div class="container">
         <div class="wrapper">

--- a/resources/views/competitions/show.blade.php
+++ b/resources/views/competitions/show.blade.php
@@ -3,9 +3,11 @@
 @section('main_content')
 
     @include('layouts.header', [
-        'title' => 'Competitions',
-        'subtitle' => 'Viewing competition ' . $competition->id
+        'title' => 'Competition',
+        'subtitle' => $competition->contest->campaign->title . ' Competition ID: ' . $competition->id
     ])
+
+    @include('layouts.back', ['link' => ['path' => route('contests.show', $competition->contest->id), 'copy' => 'back to contest']])
 
     <div class="container">
         <div class="wrapper">

--- a/resources/views/contests/show.blade.php
+++ b/resources/views/contests/show.blade.php
@@ -3,8 +3,8 @@
 @section('main_content')
 
     @include('layouts.header', [
-        'title' => 'Contests',
-        'subtitle' => 'Viewing contest ID: ' . $contest->id
+        'title' => 'Contest',
+        'subtitle' => $contest->campaign->title . ' Contest ID: ' . $contest->id
     ])
 
     <div class="container">
@@ -37,7 +37,7 @@
             <div class="container__block">
             <h2 class="heading">Data export</h1>
                 <ul class="list">
-                    <li><a href="{{ route('contests.export', $contest->id) }}">&DownArrowBar; Export</a> &mdash; CSV list of users for this contest</li>
+                    <li><a href="{{ route('contests.export', $contest->id) }}">&DownArrowBar; Export</a> &mdash; CSV list of competition IDs for this contest</li>
                 </ul>
             </div>
         </div>
@@ -49,8 +49,11 @@
                 <h2 class="heading -alpha">Messaging</h2>
                 <p>The current name of the messages sender is: <em>{{ $contest->sender_name or 'not assigned' }}</em></p>
                 <p>The current email assigned for the messages sender is: <em>{{ $contest->sender_email or 'not assigned' }}</em></p>
-                <p><a href="{{ route('contests.messages.edit', $contest->id) }}" class="button -secondary">View &amp; Edit Messages</a></p>
-                <p><a href="{{ route('messages.send', ['message' => $welcomeEmail->id, 'contest_id' => $welcomeEmail->contest_id, 'test' => true, ]) }}" class="button -secondary">Test welcome message</a></p>
+
+                <ul class="form-actions -inline">
+                    <li><a href="{{ route('contests.messages.edit', $contest->id) }}" class="button -secondary">View &amp; Edit Messages</a></li>
+                    <li><a href="{{ route('messages.send', ['message' => $welcomeEmail->id, 'contest_id' => $welcomeEmail->contest_id, 'test' => true, ]) }}" class="button -secondary">Test welcome message</a></li>
+                </ul>
             </div>
         </div>
     </div>

--- a/resources/views/layouts/back.blade.php
+++ b/resources/views/layouts/back.blade.php
@@ -1,0 +1,8 @@
+{{--
+@TODO: Maybe turn this into a breadcrumb pattern of sorts?
+--}}
+<div class="container">
+    <div class="wrapper">
+        <a class="button -muted" href="{{ $link['path'] }}">&LeftArrow; {{ $link['copy'] }}</a>
+    </div>
+</div>


### PR DESCRIPTION
#### What's this PR do?
This PR updates the titles in the header of the Leaderboard, Competition and Contest to include the actual readable, user-friendly title of the Campaign, so you can easily understand which campaign it all applies to.

Also, does a little cleanup and adds a handy new convenient `back` partial. Could eventually be turned into a breadcrumb of sorts. It includes a new `-muted` modifier class on the button pattern which maybe we can add to Forge:

![image](https://cloud.githubusercontent.com/assets/105849/15024467/f690478a-1202-11e6-8ed4-cf23cb2214bf.png)

And yes, I know the browser has a back button, but sometimes you land on an view of a competition from a different location and want to just go back to the parent contest, etc. Now you can 😉 

#### How should this be manually tested?
Do the headers in the aforementioned pages show the title of the campaign?

#### What are the relevant tickets?
Fixes #228 and other small things

---
@DoSomething/gladiator 