### PR TITLE
Use message class in manager class

### DIFF
--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -2,6 +2,7 @@
 
 namespace Gladiator\Services;
 
+use Gladiator\Models\Message;
 use Gladiator\Models\Contest;
 use Gladiator\Repositories\CacheCampaignRepository;
 use Gladiator\Repositories\UserRepositoryContract;


### PR DESCRIPTION
#### What's this PR do?
Import the message class in to the Manager class so we can actually use it. 

#### Any background context you want to provide?
```
[2016-05-05 19:01:17] production.ERROR: exception 'Symfony\Component\Debug\Exception\FatalErrorException' with message 'Class 'Gladiator\Services\Message' not found' in /var/www/gladiator/releases/20160505184844/app/Services/Manager.php:515
```

#### What are the relevant tickets?
#292 