### PR TITLE
Readding an accidentally deleted default in Correspondence.

### DIFF
--- a/app/Http/Utilities/Correspondence.php
+++ b/app/Http/Utilities/Correspondence.php
@@ -35,6 +35,7 @@ class Correspondence
             'subject' => 'Is everything ok, :first_name:?',
             'body' => "I noticed you haven’t upload a picture of your :reportback_noun: :reportback_verb: to :campaign_title: yet. Just wanted to see if everything is ok!\n\rIf you are able, you still have until :leaderboard_msg_day-1: to be included in the next update! Take a picture and upload your photo [here](:prove_it_link:).\n\rLet me know if I can help you, :first_name:.\n\r:sender_name:",
             'pro_tip' => null,
+            'signoff' => null,
         ],
         [
             'type' => 'reminder',


### PR DESCRIPTION
#### What's this PR do?
This PR re-adds a missing item in the default Correspondence array that was accidentally deleted in #293.

#### How should this be manually tested?
Does `artisan db:seed` still throw errors? No? Great!

#### What are the relevant tickets?
🌵 

---
@DoSomething/gladiator 
