### PR TITLE
Add checks to make sure we got a reportback from phoenix

### DIFF
--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -211,11 +211,13 @@ class Email
         if (isset($featuredReportback) && isset($featuredReportback->reportback_id) && isset($featuredReportback->reportback_item_id)) {
             $reportback = $this->manager->appendReportbackItemToMessage($featuredReportback->reportback_id, $featuredReportback->reportback_item_id);
 
-            return $featuredReportback = [
-                'shoutout' => $featuredReportback->shoutout,
-                'image_url' => $reportback->media->uri,
-                'caption' => $reportback->caption,
-            ];
+            if ($reportback) {
+                return $featuredReportback = [
+                    'shoutout' => $featuredReportback->shoutout,
+                    'image_url' => $reportback->media->uri,
+                    'caption' => $reportback->caption,
+                ];
+            }
         }
 
         return null;

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -467,17 +467,21 @@ class Manager
      *
      * @param  string  $reportback_id
      * @param  string  $reportback_item_id
-     * @return object
+     * @return object|null
      */
     public function appendReportbackItemToMessage($reportback_id, $reportback_item_id)
     {
         $reportback = $this->phoenix->getReportback($reportback_id, $reportback_item_id);
 
-        // Remove the nonsense 0,1,2 array keys and key by the reportback item id.
-        $reportback_items = collect($reportback->reportback_items->data)->keyBy('id');
+        if ($reportback) {
+            // Remove the nonsense 0,1,2 array keys and key by the reportback item id.
+            $reportback_items = collect($reportback->reportback_items->data)->keyBy('id');
 
-        // Find the matching reportback item, and return the item.
-        return $reportback_items->get($reportback_item_id);
+            // Find the matching reportback item, and return the item.
+            return $reportback_items->get($reportback_item_id);
+        } else {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?

Add checks to make sure we actually got a reportback back from phoenix. I was seeing issues with leaderboard emails when a featured reportback was set, but either the RID or Item id was bad. The email would fail cause it didn't check that it got a good response back. 

#### How should this be manually tested?

Add some invalid IDs to a leaderboard email and try to test. It should still send out but will not have the featured RB cause it ain't real or don't exist. 

#### What are the relevant tickets?
Fixes #288 

@angaither @weerd @deadlybutter 
