### PR TITLE
Updating waiting room edit form to not use Form facade.

### DIFF
--- a/resources/views/contests/partials/_form_contest.blade.php
+++ b/resources/views/contests/partials/_form_contest.blade.php
@@ -1,21 +1,21 @@
 <div class="form-item -padded">
     <label class="field-label" for="signup_start_date">Signup Start Date:</label>
-    <input type="date" name="signup_start_date" id="signup_start_date" class="text-field" value="{{ isset($contest) ? format_date_form_field($contest->waitingRoom, 'signup_start_date') : '' }}"></input>
+    <input type="date" name="signup_start_date" id="signup_start_date" class="text-field" value="{{ isset($contest) ? format_date_form_field($contest->waitingRoom, 'signup_start_date') : '' }}" />
 </div>
 
 <div class="form-item -padded">
     <label class="field-label" for="signup_end_date">Signup End Date:</label>
-    <input type="date" name="signup_end_date" id="signup_end_date"  class="text-field" value="{{ isset($contest) ? format_date_form_field($contest->waitingRoom, 'signup_end_date') : '' }}"></input>
+    <input type="date" name="signup_end_date" id="signup_end_date"  class="text-field" value="{{ isset($contest) ? format_date_form_field($contest->waitingRoom, 'signup_end_date') : '' }}" />
 </div>
 
 <div class="form-item -padded">
     <label class="field-label" for="id">Campaign ID:</label>
-    <input type="number" name="campaign_id" id="campaign_id" class="text-field" placeholder="1234" value="{{ $contest->campaign_id or old('campaign_id') }}"/>
+    <input type="number" name="campaign_id" id="campaign_id" class="text-field" placeholder="1234" value="{{ $contest->campaign_id or old('campaign_id') }}" />
 </div>
 
 <div class="form-item -padded">
     <label class="field-label" for="id">Campaign Run ID:</label>
-    <input type="number" name="campaign_run_id" id="campaign_run_id" class="text-field" placeholder="42" value="{{ $contest->campaign_run_id or old('campaign_run_id') }}"/>
+    <input type="number" name="campaign_run_id" id="campaign_run_id" class="text-field" placeholder="42" value="{{ $contest->campaign_run_id or old('campaign_run_id') }}" />
 </div>
 
 <div class="form-item -padded">

--- a/resources/views/waitingrooms/edit.blade.php
+++ b/resources/views/waitingrooms/edit.blade.php
@@ -10,11 +10,11 @@
     <div class="container">
         <div class="wrapper">
             <div class="container__block -narrow">
-                {!! Form::model($room, ['method' => 'PATCH','route' => ['waitingrooms.update', $room->id]]) !!}
+                <form method="POST" action="{{ route('waitingrooms.update', $room->id) }}">
+                    {{ method_field('PATCH') }}
 
                     @include('waitingrooms.partials._form_waitingrooms')
-
-                {!! Form::close() !!}
+                </form>
             </div>
         </div>
     </div>

--- a/resources/views/waitingrooms/partials/_form_waitingrooms.blade.php
+++ b/resources/views/waitingrooms/partials/_form_waitingrooms.blade.php
@@ -1,20 +1,22 @@
+{{ csrf_field() }}
+
 @include('layouts.errors')
 
 <div class="form-item -padded">
-    {{ Form::label('contest_id', 'Contest ID:', ['class' => 'field-label']) }}
-    {{ Form::text('contest_id', NULL, ['class' => 'text-field', 'readonly' => 'readonly']) }}
+    <label for="contest_id" class="field-label">Contest ID:</label>
+    <input type="number" name="contest_id" id="contest_id" class="text-field" readonly value="{{ $room->contest_id or old('contest_id') }}"></input>
 </div>
 
 <div class="form-item -padded">
-    {!! Form::label('signup_start_date', 'Signup Start Date: ', ['class' => 'field-label']) !!}
-    {!! Form::date('signup_start_date', (isset($room->signup_start_date)) ? $room->signup_start_date : NULL, ['class' => 'text-field']) !!}
+    <label for="signup_start_date" class="field-label">Signup Start Date:</label>
+    <input type="date" name="signup_start_date" id="signup_start_date" class="text-field" value="{{ isset($room) ? format_date_form_field($room, 'signup_start_date') : '' }}" />
 </div>
 
 <div class="form-item -padded">
-    {!! Form::label('signup_end_date', 'Signup End Date: ', ['class' => 'field-label']) !!}
-    {!! Form::date('signup_end_date', (isset($room->signup_end_date)) ? $room->signup_end_date : NULL, ['class' => 'text-field']) !!}
+    <label for="signup_end_date" class="field-label">Signup End Date:</label>
+    <input type="date" name="signup_end_date" id="signup_end_date" class="text-field" value="{{ isset($room) ? format_date_form_field($room, 'signup_end_date') : '' }}" />
 </div>
 
 <div class="form-item -padded">
-    {{ Form::submit('Submit', ['class' => 'button']) }}
+    <input type="submit" value="Submit" class="button" />
 </div>


### PR DESCRIPTION
#### What's this PR do?
This PR does a little bit of form cleanup and removes the use of the `Form` facade in the WaitingRoom edit form.

#### How should this be manually tested?
Try editing a Waiting Room for a Contest and see if it breaks!

#### Any background context you want to provide?
We're aiming to remove the use of the `Form` facade. While it used to be great for use in Laravel projects, there are times when it causes more problems, and it's typically better to just control the output of the HTML markup more directly.

#### What are the relevant tickets?
🌵 

---
@DoSomething/gladiator 