### PR TITLE
Welcome message bug

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -99,6 +99,7 @@ class UsersController extends ApiController
         $params = [
             'type' => 'welcome',
             'key' => 0,
+            'contest_id' => $contest->id,
         ];
 
         $this->manager->sendEmail($user, $contest, $params);

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -93,7 +93,7 @@ class UsersController extends ApiController
         }
 
         $contest->waitingRoom->users()->attach($user->id);
-        $this->manager->appendCampaign($contest);
+        $contest = $this->manager->appendCampaign($contest);
 
         // Fire off welcome Email
         $params = [

--- a/app/Http/Controllers/MessagesController.php
+++ b/app/Http/Controllers/MessagesController.php
@@ -92,7 +92,9 @@ class MessagesController extends Controller
     {
         // Get competition with activity.
         $competitionId = request('competition_id');
-        // $competition = null;
+
+        $contest = Contest::find(request('contest_id'));
+        $this->manager->appendCampaign($contest);
 
         if ($competitionId) {
             $competition = Competition::find($competitionId);
@@ -127,6 +129,7 @@ class MessagesController extends Controller
         $resources = [
             'message' => $message,
             'competition' => isset($competition) ? $competition : null,
+            'contest' => $contest,
             'users' => $users,
             'test' => request('test'),
         ];

--- a/app/Http/Controllers/MessagesController.php
+++ b/app/Http/Controllers/MessagesController.php
@@ -94,7 +94,7 @@ class MessagesController extends Controller
         $competitionId = request('competition_id');
 
         $contest = Contest::find(request('contest_id'));
-        $this->manager->appendCampaign($contest);
+        $contest = $this->manager->appendCampaign($contest);
 
         if ($competitionId) {
             $competition = Competition::find($competitionId);

--- a/app/Http/Controllers/Settings/MessagesSettingsController.php
+++ b/app/Http/Controllers/Settings/MessagesSettingsController.php
@@ -45,8 +45,8 @@ class MessagesSettingsController extends Controller
             foreach ($items as $key => $data) {
                 $data['type'] = $type;
                 $data['key'] = $key;
-
                 $message = MessageSetting::where('type', $type)->where('key', $key)->first();
+
 
                 $attributes = $message->getFillable();
 


### PR DESCRIPTION
#### What's this PR do?
I found two problems.

1) Welcome test messages were f**ked cause we weren't passing in the contest explicity and it was causing errors when trying to grab information about the contest in the `Email` class.

2) Welcome emails were f**ked cause we pass in a `$params` array that we use to query the `Message` table but we were just looking for the first email of type welcome with key 0...

We probably didn't notice cause mostly all the welcome emails were the same..but if you updated one for a specific contest, we didn't care. 

#### How should this be manually tested?

Go to a contest, customize the welcome message.

Post to `/users` and you should get a welcome email with the right content. 

also go ahead and send yourself a test email. that should work as well. 

#### Any background context you want to provide?

![giphy 1](https://cloud.githubusercontent.com/assets/1700409/16430875/cfe1dd5a-3d4b-11e6-8ac9-d028dc6d29e0.gif)


#### What are the relevant tickets?

Fixes #323