### PR TITLE
Markdown support for image tags

### DIFF
--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -104,6 +104,7 @@ class Email
 
         foreach ($parsableProperties as $prop) {
             $processedMessage[$prop] = $this->replaceTokens($tokens, $message->$prop);
+            $processedMessage[$prop] = $this->parseImageTags($processedMessage[$prop]);
             $processedMessage[$prop] = $this->parseLinks($processedMessage[$prop]);
             $processedMessage[$prop] = nl2br($processedMessage[$prop]);
         }
@@ -131,6 +132,16 @@ class Email
     protected function parseLinks($string)
     {
         return preg_replace('/\[([^\[]+)\]\(([^\)]+)\)/', '<a href=\'\2\'>\1</a>', $string);
+    }
+
+    /**
+     * Handles regex replacement that supports a markdown syntax for image tags.
+     *
+     * @param  string $string
+     */
+    protected function parseImageTags($string)
+    {
+        return preg_replace('/!\[([^\[]+)\]\(([^\)]+)\)/', '<img src=\'\2\' alt=\'\1\'>', $string);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?

Adds markdown syntax support for image tags. 

Turn this: 

![image](https://cloud.githubusercontent.com/assets/1700409/16817936/28b99cf6-4913-11e6-81d3-ed9fa7606440.png)

into this:

![pushitemail](https://cloud.githubusercontent.com/assets/1700409/16817946/3afff64e-4913-11e6-89ec-691fecf4d017.gif)


#### How should this be manually tested?
Use it in an email message template and send a test!

#### What are the relevant tickets?
Fixes #316 
