### PR TITLE
Email Image toggle

### DIFF
--- a/app/Http/Utilities/Correspondence.php
+++ b/app/Http/Utilities/Correspondence.php
@@ -81,6 +81,7 @@ class Correspondence
             'body' => "Hello Competitors,\n\rHere is your first official :campaign_title: competition update! The competition ends on :end_date:. Finish in the top 3 in :reportback_noun: :reportback_verb: and win:\n\r- 1st place: ­ $100 amex card\r\n- 2nd place: ­ $50 amex card\r\n- 3rd place: ­ $25 amex card\n\rTwo more weeks to increase your number of :reportback_noun: :reportback_verb: to move up the leaderboard! [Upload your photos here](:prove_it_link:).\n\r:pro_tip:\n\rNext :reportback_noun: photo update will be due :leaderboard_msg_day-1: before 10pm est.\n\rHere is the leaderboard! Shoutouts to the top 3 below:",
             'pro_tip' => null,
             'signoff' => null,
+            'show_images' => true,
         ],
         [
             'type' => 'leaderboard',
@@ -90,6 +91,7 @@ class Correspondence
             'body' => "Hello, competitors-- \n\r1 more week! This :campaign_title: competition ends on :end_date:, so it’s time to make your mark.\n\r:pro_tip:\n\rA final photo with your :reportback_noun: photo update will be due :leaderboard_msg_day-1: before 10pm EST. [Upload yours here](:prove_it_link:).\n\rHere is the leaderboard! Shoutouts to the top 3 below:\n\r1 more week to make your mark and climb up the leaderboard!",
             'pro_tip' => null,
             'signoff' => '1 more week to make your mark and climb up the leaderboard!',
+            'show_images' => true,
         ],
         [
             'type' => 'leaderboard',
@@ -99,6 +101,7 @@ class Correspondence
             'body' => "This is it, the final leaderboard and results. Thank you for spending these last 3 weeks, working hard not only to climb the leaderboard, but also to affect lives around you and make the world a better place.\n\rHere is your final leaderboard. Pics, prizes and honorable mentions below:\n\r",
             'pro_tip' => null,
             'signoff' => null,
+            'show_images' => true,
         ],
     ];
 

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -11,7 +11,7 @@ class Message extends Model
      *
      * @return array
      */
-    protected $fillable = ['contest_id', 'type', 'key', 'label', 'subject', 'body', 'pro_tip', 'signoff'];
+    protected $fillable = ['contest_id', 'type', 'key', 'label', 'subject', 'body', 'pro_tip', 'signoff', 'show_images'];
 
     /**
      * Excluded attributes that are not customizeable.

--- a/app/Repositories/MessageRepository.php
+++ b/app/Repositories/MessageRepository.php
@@ -120,6 +120,10 @@ class MessageRepository
                 $data['type'] = $type;
                 $data['key'] = $key;
 
+                // @TODO - When the 'show_images' checkbox is not checked,
+                // The `show_images` property is not sent in the request so we
+                // manually set it here. Let's figure out a better way to do this,
+                // maybe in a MessageRequest class?
                 if ($data['type'] === 'leaderboard') {
                     if (! array_key_exists('show_images', $data)) {
                         $data['show_images'] = 0;

--- a/app/Repositories/MessageRepository.php
+++ b/app/Repositories/MessageRepository.php
@@ -121,7 +121,7 @@ class MessageRepository
                 $data['key'] = $key;
 
                 if ($data['type'] === 'leaderboard') {
-                    if (!array_key_exists('show_images', $data)) {
+                    if (! array_key_exists('show_images', $data)) {
                         $data['show_images'] = 0;
                     }
                 }

--- a/app/Repositories/MessageRepository.php
+++ b/app/Repositories/MessageRepository.php
@@ -120,6 +120,12 @@ class MessageRepository
                 $data['type'] = $type;
                 $data['key'] = $key;
 
+                if ($data['type'] === 'leaderboard') {
+                    if (!array_key_exists('show_images', $data)) {
+                        $data['show_images'] = 0;
+                    }
+                }
+
                 $this->update($contest, $data);
             }
         }

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -51,6 +51,7 @@ class Email
     public function __construct($resources)
     {
         $this->message = $resources['message'];
+
         $this->competition = isset($resources['competition']) ? $resources['competition'] : null;
 
         // If a contest is passed in the resources used that, otherwise grab it from the competition.
@@ -101,6 +102,7 @@ class Email
         $parsableProperties = ['subject', 'body', 'signoff', 'pro_tip', 'shoutout'];
         $processedMessage['type'] = $message->type;
         $processedMessage['key'] = $message->key;
+        $processedMessage['show_images'] = $message->show_images;
 
         foreach ($parsableProperties as $prop) {
             $processedMessage[$prop] = $this->replaceTokens($tokens, $message->$prop);

--- a/database/migrations/2016_08_02_171141_add_image_toggle_to_messages_table.php
+++ b/database/migrations/2016_08_02_171141_add_image_toggle_to_messages_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddImageToggleToMessagesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->boolean('show_images')->after('pro_tip')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->dropColumn('show_images');
+        });
+    }
+}

--- a/resources/views/contests/partials/_form_contest_messaging_leaderboard.blade.php
+++ b/resources/views/contests/partials/_form_contest_messaging_leaderboard.blade.php
@@ -10,7 +10,7 @@
 
 <div class="form-item -padded">
     <label class="option -checkbox">
-        <input checked type="checkbox" value="1" name="{{ correspondence()->getAttribute($message, 'show_images') }}" id="{{ correspondence()->getAttribute($message, 'show_images') }}">
+        <input @if (correspondence()->get($message, 'show_images')) checked @endif type="checkbox" value="1" name="{{ correspondence()->getAttribute($message, 'show_images') }}" id="{{ correspondence()->getAttribute($message, 'show_images') }}">
         <span class="option__indicator"></span>
         <span>Show images</span>
     </label>

--- a/resources/views/contests/partials/_form_contest_messaging_leaderboard.blade.php
+++ b/resources/views/contests/partials/_form_contest_messaging_leaderboard.blade.php
@@ -10,7 +10,7 @@
 
 <div class="form-item -padded">
     <label class="option -checkbox">
-        <input checked type="checkbox" id="show-image-toggle">
+        <input checked type="checkbox" value="1" name="{{ correspondence()->getAttribute($message, 'show_images') }}" id="{{ correspondence()->getAttribute($message, 'show_images') }}">
         <span class="option__indicator"></span>
         <span>Show images</span>
     </label>

--- a/resources/views/contests/partials/_form_contest_messaging_leaderboard.blade.php
+++ b/resources/views/contests/partials/_form_contest_messaging_leaderboard.blade.php
@@ -7,3 +7,11 @@
     <label class="field-label" for="{{ correspondence()->getAttribute($message, 'signoff') }}">Signoff:</label>
     <textarea class="text-field" name="{{ correspondence()->getAttribute($message, 'signoff') }}" id="{{ correspondence()->getAttribute($message, 'signoff') }}" rows="3">{{ correspondence($message, 'signoff') }}</textarea>
 </div>
+
+<div class="form-item -padded">
+    <label class="option -checkbox">
+        <input checked type="checkbox" id="show-image-toggle">
+        <span class="option__indicator"></span>
+        <span>Show images</span>
+    </label>
+</div>

--- a/resources/views/messages/leaderboard.blade.php
+++ b/resources/views/messages/leaderboard.blade.php
@@ -5,6 +5,7 @@
         'messageKey' => $content['key'],
         'featuredReportback' => $content['featuredReportback'],
         'reportbackInfo' => $content['reportbackInfo'],
+        'showImages' => $content['show_images'],
     ])
 @endif
 
@@ -13,6 +14,7 @@
         'messageKey' => $content['key'],
         'topThree' => $content['topThree'],
         'reportbackInfo' => $content['reportbackInfo'],
+        'showImages' => $content['show_images'],
     ])
 @endif
 

--- a/resources/views/messages/partials/_reportback.blade.php
+++ b/resources/views/messages/partials/_reportback.blade.php
@@ -26,6 +26,8 @@
     <p>{{ $shoutout or '' }}</p>
 @endif
 
-<img src="{{ $image }}" width="200" />
+@if ($showImages)
+    <img src="{{ $image }}" width="200" />
+@endif
 
 <p>"<em>{{ $caption }}</em>"</p>


### PR DESCRIPTION
#### What's this PR do?
Adds a checkbox to the message edit page that will toggle the display of images or not.

#### How should this be manually tested?
Go to a contest, edit the messages, toggle the "show images" check box on/off and then send yourself a test of a leaderboard message.

If it is "on" you should see reportback images, if it "off" you should not.

#### Any background context you want to provide?
This is what the checkbox looks like:
![image](https://cloud.githubusercontent.com/assets/1700409/17342542/d6964a68-58c7-11e6-99ca-ed663755d1c9.png)

This is how it looks in the DB: 
![image](https://cloud.githubusercontent.com/assets/1700409/17342678/4d8d64e4-58c8-11e6-80db-2ba984eb9f81.png)


#### What are the relevant tickets?
Fixes #331 