### PR TITLE
Added a 'share_link' token to emails.

### DIFF
--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -84,7 +84,8 @@ class Email
             ':reportback_noun:'       => strtolower($this->contest->campaign->reportback_info->noun),
             ':reportback_verb:'       => strtolower($this->contest->campaign->reportback_info->verb),
             ':sender_name:'           => $this->contest->sender_name,
-            ':rules_url:'            => ! is_null($this->competition) ? $this->competition->rules_url : '',
+            ':rules_url:'             => ! is_null($this->competition) ? $this->competition->rules_url : '',
+            ':share_link:'            => url(config('services.phoenix.uri') .'/us/node/' . $this->contest->campaign_id . '?source=user/' . $user->id),
         ];
 
         return $tokens;


### PR DESCRIPTION
#### What's this PR do?
- this prefixes the links with /us/ so that when you hit phoenix a redirect doesn't prevent that query string from persisting.
- the token is `:share_link:`

#### How should this be manually tested?
Add `:share_link:` into an email and test the send, it should be populated with
`ds.org/us/node/[nid]?source=user/[id]`

#### Any background context you want to provide?
- this is so gladiator emails can have those unique share links
- since we only have US competitions now (DoSomething/phoenix/issues/6849) I prefixed the link with `/us/` so this will NOT work if we run this on global things.

#### What are the relevant tickets?
Fixes #334 


cc @ngjo 
