### PR TITLE
341: Capitalized first name for email sends

### DIFF
--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -76,7 +76,7 @@ class Email
         $tokens = [
             ':campaign_title:'        => $this->contest->campaign->title,
             ':end_date:'              => ! is_null($this->competition) ? $this->competition->competition_end_date->format('F d, Y') : '',
-            ':first_name:'            => $user->first_name,
+            ':first_name:'            => ucwords($user->first_name),
             ':leaderboard_msg_day:'   => ! is_null($this->competition) ? get_day_of_week($this->competition->leaderboard_msg_day) : '',
             ':leaderboard_msg_day-1:' => ! is_null($this->competition) ? get_day_of_week($this->competition->leaderboard_msg_day - 1) : '',
             ':pro_tip:'               => $this->message->pro_tip,


### PR DESCRIPTION
#### What's this PR do?
Formatted first_name token to be capitalized in Email.php using ucwords() function.

#### How should this be manually tested?
Send test email to (test) user with lower case first name(s), such as 'rogue' or 'rogue marie.' Email received should capitalize the first name(s), such as 'Rogue' or 'Rogue Marie.'

#### Any background context you want to provide?
No other background context.

#### What are the relevant tickets?
Fixes #341 
