### PR TITLE
336: Adding 'signup start date' to the overview table

### DIFF
--- a/resources/views/contests/index.blade.php
+++ b/resources/views/contests/index.blade.php
@@ -24,6 +24,7 @@
                                 <th class="table__cell">ID</th>
                                 <th class="table__cell">Campaign</th>
                                 <th class="table__cell">Campaign Run</th>
+                                <th class="table__cell">Signup Start Date</th>
                                 <th class="table__cell">Signup End Date</th>
                                 <th class="table__cell">Signups</th>
                                 <th class="table__cell">Waiting Room Status</th>
@@ -38,6 +39,7 @@
                                     <td class="table__cell"><a href="{{ route('contests.show', $contest->id) }}">{{ $contest->id }}</a></td>
                                     <td class="table__cell"><a href="{{ url(config('services.phoenix.uri') .'/node/' . $contest->campaign_id) }}" target="_blank">{{ $contest->campaign->title or 'No title available' }}</a></td>
                                     <td class="table__cell">{{ $contest->campaign_run_id }}</td>
+                                    <td class="table__cell">{{ $contest->waitingRoom->signup_start_date->format('F d, Y') }}</td>
                                     <td class="table__cell">{{ $contest->waitingRoom->signup_end_date->format('F d, Y') }}</td>
                                     <td class="table__cell"><a href="{{ route('waitingrooms.show', $contest->waitingroom->id) }}">{{ $contest->waitingroom->users->count() }}</a></td>
                                     <td class="table__cell">


### PR DESCRIPTION
#### What's this PR do?
Added 'Signup Start Date' column to Contest Overview table.

#### How should this be manually tested?
Check that the column 'Signup Start Date' appears in the Contest Overview table. 

#### Any background context you want to provide?
None.

#### What are the relevant tickets?
Fixes #336 
