### PR TITLE
Contest stats

### DIFF
--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -85,9 +85,26 @@ class ContestsController extends Controller
     {
         $contest = $this->manager->collectContestInfo($contest->id);
         $contest = $this->manager->appendCampaign($contest);
+        $competition_statistics = [];
+
+        foreach($contest->competitions as $competition) {
+          $key = generate_model_flash_session_key($competition, ['includeActivity' => true]);
+
+          if (session()->has($key)) {
+              $competition = session($key);
+
+              session()->reflash();
+          } else {
+              $competition = $this->manager->getCompetitionOverview($competition, true);
+          }
+
+          array_push($competition_statistics, $this->manager->getStatisticsForCompetition($competition));
+        }
+
+        $statistics = $this->manager->getStatisticsForContest($contest, $competition_statistics);
         $welcomeEmail = Message::where('contest_id', '=', $contest->id)->where('type', '=', 'welcome')->firstOrFail();
 
-        return view('contests.show', compact('contest', 'welcomeEmail'));
+        return view('contests.show', compact('contest', 'welcomeEmail','statistics'));
     }
 
     /**

--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -85,26 +85,18 @@ class ContestsController extends Controller
     {
         $contest = $this->manager->collectContestInfo($contest->id);
         $contest = $this->manager->appendCampaign($contest);
-        $competition_statistics = [];
 
-        foreach($contest->competitions as $competition) {
-          $key = generate_model_flash_session_key($competition, ['includeActivity' => true]);
-
-          if (session()->has($key)) {
-              $competition = session($key);
-
-              session()->reflash();
-          } else {
-              $competition = $this->manager->getCompetitionOverview($competition, true);
-          }
-
-          array_push($competition_statistics, $this->manager->getStatisticsForCompetition($competition));
+        $key = generate_model_flash_session_key($contest);
+        if (session()->has($key)) {
+            $contest = session($key);
+            session()->reflash();
+        } else {
+            $contest = $this->manager->getContestOverview($contest);
         }
 
-        $statistics = $this->manager->getStatisticsForContest($contest, $competition_statistics);
         $welcomeEmail = Message::where('contest_id', '=', $contest->id)->where('type', '=', 'welcome')->firstOrFail();
 
-        return view('contests.show', compact('contest', 'welcomeEmail','statistics'));
+        return view('contests.show', compact('contest', 'welcomeEmail'));
     }
 
     /**

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -9,6 +9,7 @@ use Gladiator\Repositories\UserRepositoryContract;
 use Gladiator\Services\Northstar\Northstar;
 use Gladiator\Services\Phoenix\Phoenix;
 use Gladiator\Events\QueueMessageRequest;
+use Log;
 
 class Manager
 {
@@ -273,6 +274,37 @@ class Manager
         foreach ($competition->activity['active'] as $user) {
             $statistics['impactQuantity'] += intval($user->reportback->quantity);
         }
+
+        return (object) $statistics;
+    }
+
+    /**
+     * Get statistics for the specified contest by aggregating its competitions statistics.
+     *
+     * @param  \Gladiator\Models\Contest  $contest
+     * @return object
+     */
+    public function getStatisticsForContest(Contest $contest, $competition_statistics)
+    {
+        if (! $contest) {
+             return null;
+        }
+
+        $statistics = [];
+        $competitions = $contest->competitions;
+
+        $statistics['totalContestContestants'] = 0;
+        $statistics['totalContestReportbacks'] = 0;
+        $statistics['contestImpactQuantity'] = 0;
+
+        foreach ($competition_statistics as $competition) {
+            //$competition_statistics = $this->getStatisticsForCompetition($competition);
+            $statistics['totalContestContestants'] += $competition->totalContestants;
+            $statistics['totalContestReportbacks']+= $competition->totalReportbacks;
+            $statistics['contestImpactQuantity'] += $competition->impactQuantity;
+        }
+
+        $statistics['contestReportbackRate'] = intval(round(($statistics['totalContestReportbacks'] / $statistics['totalContestContestants']) * 100));
 
         return (object) $statistics;
     }

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -279,34 +279,71 @@ class Manager
     }
 
     /**
+     * Get the full contest overview.
+     *
+     * @param  \Gladiator\Models\Contest  $contest
+     * @return \Gladiator\Models\Contest
+     */
+    public function getContestOverview(Contest $contest)
+    {
+        foreach($contest->competitions as $competition) {
+
+          $key = generate_model_flash_session_key($competition, ['includeActivity' => true]);
+          if (session()->has($key)) {
+              $competition = session($key);
+              session()->reflash();
+          } else {
+              $competition = $this->getCompetitionOverview($competition, true);
+          }
+          $competition->statistics = $this->getStatisticsForCompetition($competition);
+        }
+
+        $contest->statistics = $this->getStatisticsForContest($contest);
+
+        $key = generate_model_flash_session_key($contest);
+        session()->flash($key, $contest);
+
+        return $contest;
+    }
+
+    /**
      * Get statistics for the specified contest by aggregating its competitions statistics.
      *
      * @param  \Gladiator\Models\Contest  $contest
      * @return object
      */
-    public function getStatisticsForContest(Contest $contest, $competition_statistics)
+    public function getStatisticsForContest(Contest $contest)
     {
-        if (! $contest) {
-             return null;
-        }
-
         $statistics = [];
-        $competitions = $contest->competitions;
 
-        $statistics['totalContestContestants'] = 0;
-        $statistics['totalContestReportbacks'] = 0;
-        $statistics['contestImpactQuantity'] = 0;
+        if (! $contest) {
+          return null;
 
-        foreach ($competition_statistics as $competition) {
-            //$competition_statistics = $this->getStatisticsForCompetition($competition);
-            $statistics['totalContestContestants'] += $competition->totalContestants;
-            $statistics['totalContestReportbacks']+= $competition->totalReportbacks;
-            $statistics['contestImpactQuantity'] += $competition->impactQuantity;
+          // Zero competitions in the contest
+        } elseif ($contest->competitions->count() == 0) {
+          $statistics['totalContestContestants'] = 0;
+          $statistics['totalContestReportbacks'] = 0;
+          $statistics['contestImpactQuantity'] = 0;
+          $statistics['contestReportbackRate'] = 0;
+
+          return (object) $statistics;
+
+        } else {
+
+          $statistics['totalContestContestants'] = 0;
+          $statistics['totalContestReportbacks'] = 0;
+          $statistics['contestImpactQuantity'] = 0;
+
+          foreach ($contest->competitions as $competition) {
+              $statistics['totalContestContestants'] += $competition->statistics->totalContestants;
+              $statistics['totalContestReportbacks']+= $competition->statistics->totalReportbacks;
+              $statistics['contestImpactQuantity'] += $competition->statistics->impactQuantity;
+          }
+
+          $statistics['contestReportbackRate'] = intval(round(($statistics['totalContestReportbacks'] / $statistics['totalContestContestants']) * 100));
+
+          return (object) $statistics;
         }
-
-        $statistics['contestReportbackRate'] = intval(round(($statistics['totalContestReportbacks'] / $statistics['totalContestContestants']) * 100));
-
-        return (object) $statistics;
     }
 
     /**

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -93,16 +93,24 @@ function format_timestamp_for_display($timestamp)
 function generate_model_flash_session_key($model, $options = [])
 {
     if ($model instanceof \Gladiator\Models\Competition) {
-        $key = 'contest_' . $model->contest_id . '-' . 'competition_' . $model->id;
+      $key = 'contest_' . $model->contest_id . '-' . 'competition_' . $model->id;
 
-        if (isset($options['includeActivity']) && $options['includeActivity']) {
-            $key .= '-activity_included';
-        }
+      if (isset($options['includeActivity']) && $options['includeActivity']) {
+          $key .= '-activity_included';
+      }
+      return $key;
 
-        return $key;
+    } elseif ($model instanceof \Gladiator\Models\Contest){
+      $key = 'contest_' . $model->id;
+
+      if (isset($options['includeActivity']) && $options['includeActivity']) {
+          $key .= '-activity_included';
+      }
+      return $key;
+
+    } else {
+      return '';
     }
-
-    return '';
 }
 
 /**

--- a/resources/views/contests/show.blade.php
+++ b/resources/views/contests/show.blade.php
@@ -69,6 +69,20 @@
         </div>
     </div>
 
+    <div class="container">
+        <div class="wrapper">
+            <div class="container__block">
+                <h2 class="heading">Statistics</h2>
+                <ul class="list">
+                    <li>Total number of contestants in contest: <strong>{{ $statistics->totalContestContestants }}</strong></li>
+                    <li>Number of contestants who have reported back: <strong>{{ $statistics->totalContestReportbacks }}</strong></li>
+                    <li>Reportback rate: <strong>{{ $statistics->contestReportbackRate . '%' }}</strong></li>
+                    <li>Approved reportbacks impact quantity: <strong>{{ number_format($statistics->contestImpactQuantity) . ' ' . $contest->campaign->reportback_info->noun . ' ' . $contest->campaign->reportback_info->verb }} </strong></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
     @if ($contest->competitions->count())
     <div class="container">
         <div class="wrapper">

--- a/resources/views/contests/show.blade.php
+++ b/resources/views/contests/show.blade.php
@@ -74,10 +74,10 @@
             <div class="container__block">
                 <h2 class="heading">Statistics</h2>
                 <ul class="list">
-                    <li>Total number of contestants in contest: <strong>{{ $statistics->totalContestContestants }}</strong></li>
-                    <li>Number of contestants who have reported back: <strong>{{ $statistics->totalContestReportbacks }}</strong></li>
-                    <li>Reportback rate: <strong>{{ $statistics->contestReportbackRate . '%' }}</strong></li>
-                    <li>Approved reportbacks impact quantity: <strong>{{ number_format($statistics->contestImpactQuantity) . ' ' . $contest->campaign->reportback_info->noun . ' ' . $contest->campaign->reportback_info->verb }} </strong></li>
+                    <li>Total number of contestants in contest: <strong>{{ $contest->statistics->totalContestContestants }}</strong></li>
+                    <li>Number of contestants who have reported back: <strong>{{ $contest->statistics->totalContestReportbacks }}</strong></li>
+                    <li>Reportback rate: <strong>{{ $contest->statistics->contestReportbackRate . '%' }}</strong></li>
+                    <li>Approved reportbacks impact quantity: <strong>{{ number_format($contest->statistics->contestImpactQuantity) . ' ' . $contest->campaign->reportback_info->noun . ' ' . $contest->campaign->reportback_info->verb }} </strong></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
#### What's this PR do?

Added contest-level statistics by aggregating competition statistics of specified contests. Tried to optimize performance by adding flash storage at contest level. 
#### How should this be manually tested?

Keep track of each competition statistic for a contest. Add up these competitions statistics. Verify that these manual calculations match the statistics displayed in the contest site. 
#### Any background context you want to provide?

None.
#### What are the relevant tickets?

Ref #343
