### PR TITLE
Only remove a users from the waiting room being split

### DIFF
--- a/app/Models/WaitingRoom.php
+++ b/app/Models/WaitingRoom.php
@@ -97,6 +97,7 @@ class WaitingRoom extends Model
     {
         $startDate = Carbon::now()->startOfDay();
         $endDate = new Carbon($request->competition_end_date);
+        $waitingRoom = $contest->waitingRoom;
 
         foreach ($split as $competitionGroup) {
             // For each split, create a competition.
@@ -113,8 +114,8 @@ class WaitingRoom extends Model
             foreach ($competitionGroup as $userId) {
                 $user = User::find($userId);
 
-                // Remove them from the waiting room pivot table
-                $user->waitingRooms()->detach();
+                // Remove the user from the waiting room being split.
+                $user->waitingRooms()->detach($waitingRoom->id);
 
                 // Add them to the competitions pivot table
                 $user->competitions()->attach($competition->id);


### PR DESCRIPTION
#### What's this PR do?

Specifies which waiting room to remove a user from when splitting a waiting room into competitions.

#### How should this be manually tested?

Add a user to multiple waiting rooms and then split one of them. The user should only be removed from that waiting room being split not the other ones. 

#### Any background context you want to provide?

[Here is all the context I think you need](https://github.com/DoSomething/gladiator/issues/353)

I'm sure there is some sort of allegory we can use to talk about this one little line of code and the havoc it caused, but I don't have one at the moment. Maybe it just represents a lesson in itself.

#### What are the relevant tickets?
Fixes #353 

Also ...
Fixes #346 
Fixes #326 
