### PR TITLE
added ‘Latest Reportback Date’ column for competitions export, and fu…

### DIFF
--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -87,7 +87,7 @@ class Manager
                 $details[] = $user->reportback->why_participated;
                 $latestReportBackItem = array_pop($user->reportback->reportback_items->data);
                 $details[] = $latestReportBackItem->caption;
-                $details[] = date("m/d/Y H:i", $latestReportBackItem->created_at);
+                $details[] = date('m/d/Y H:i', $latestReportBackItem->created_at);
             }
 
             $data[] = $details;

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -65,7 +65,7 @@ class Manager
     {
         $data = [];
 
-        $data[] = ['Northstar ID', 'First Name', 'Last Name', 'Email', 'Mobile Number', 'Reportback Admin Link', 'Reported Quantity', '# Promoted', '# Approved', '# Excluded', '# Flagged', '# Pending', 'Why Participated', 'Caption for latest Reportback Item'];
+        $data[] = ['Northstar ID', 'First Name', 'Last Name', 'Email', 'Mobile Number', 'Reportback Admin Link', 'Reported Quantity', '# Promoted', '# Approved', '# Excluded', '# Flagged', '# Pending', 'Why Participated', 'Caption for latest Reportback Item', 'Latest Reportback Date'];
 
         foreach ($users as $user) {
             $details = [
@@ -85,7 +85,9 @@ class Manager
                 $details[] = $user->reportback->reportback_items->count_by_status['flagged'];
                 $details[] = $user->reportback->reportback_items->count_by_status['pending'];
                 $details[] = $user->reportback->why_participated;
-                $details[] = array_pop($user->reportback->reportback_items->data)->caption;
+                $latestReportBackItem = array_pop($user->reportback->reportback_items->data);
+                $details[] = $latestReportBackItem->caption;
+                $details[] = date("m/d/Y H:i", $latestReportBackItem->created_at);
             }
 
             $data[] = $details;


### PR DESCRIPTION

#### What's this PR do?
Adds Latest Reportback Date column to competitions export table, and adds the functionality for it to do so.

#### How should this be manually tested?
Go to competitions/#/leaderboard and export table! 

#### Any background context you want to provide?


#### What are the relevant tickets?
Fixes #338 