### PR TITLE
fix many to many relationship definitions after column changes

### DIFF
--- a/app/Models/Competition.php
+++ b/app/Models/Competition.php
@@ -25,7 +25,7 @@ class Competition extends Model
      */
     public function users()
     {
-        return $this->belongsToMany(User::class);
+        return $this->belongsToMany(User::class, 'competition_user', 'competition_id', 'northstar_id');
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -46,7 +46,7 @@ class User extends BaseUser
      */
     public function competitions()
     {
-        return $this->belongsToMany(Competition::class);
+        return $this->belongsToMany(Competition::class, 'competition_user', 'northstar_id', 'competition_id');
     }
 
     /**
@@ -54,7 +54,7 @@ class User extends BaseUser
      */
     public function waitingRooms()
     {
-        return $this->belongsToMany(WaitingRoom::class);
+        return $this->belongsToMany(WaitingRoom::class, 'user_waiting_room', 'northstar_id', 'waiting_room_id');
     }
 
     /**

--- a/app/Models/WaitingRoom.php
+++ b/app/Models/WaitingRoom.php
@@ -26,7 +26,7 @@ class WaitingRoom extends Model
      */
     public function users()
     {
-        return $this->belongsToMany(User::class);
+        return $this->belongsToMany(User::class, 'user_waiting_room', 'waiting_room_id', 'northstar_id');
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
We had to update the column names on the pivot tables to match changing the `id` column to `northstar_id` on the `users` table. This fixed the deploys, but now we need to update the relationships that are still expecting an `id` column. 


