### PR TITLE
fixes user page error, checks to see if reportback is a set

### DIFF
--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -507,7 +507,7 @@ class Manager
 
         $activity = $this->getActivityForUser($userId, $parameters);
 
-        if ($activity) {
+        if (isset($activity->reportback)) {
             $model->setAttribute('reportback', (object) $activity->reportback);
         } else {
             $model->setAttribute('reportback', null);


### PR DESCRIPTION
#### What's this PR do?
Fixes user page error. This PR checks to see if a reportback is a set before assigning it as the attribute of the model.

#### How should this be manually tested?
Visit user pages in local dev or qa-gladiator(once deployed) in bug issues #380 and #381 

#### Any background context you want to provide?
#381's issue was on the show.blade.php page but this fix addressed that too.

#### What are the relevant tickets?
Fixes #380  and #381 