### PR TITLE
Creates unsubscribe api endpoint and functionality to expect a compet…

### DIFF
--- a/app/Http/Controllers/Api/UnsubscribeController.php
+++ b/app/Http/Controllers/Api/UnsubscribeController.php
@@ -2,49 +2,35 @@
 
 namespace Gladiator\Http\Controllers\Api;
 
-use Gladiator\Services\Manager;
 use Gladiator\Models\Competition;
 use Gladiator\Http\Requests\UnsubscribeRequest;
 
 class UnsubscribeController extends ApiController
 {
     /**
-     * @var Gladiator\Services\Manager;
+     * Create new UnsubscribeController instance.
      */
-    protected $manager;
+    public function __construct()
+    {
+        $this->middleware('auth.api');
+    }
 
+    /**
+     * Unsubscribe user from competition.
+     *
+     * @param  Gladiator\Http\Requests\UnsubscribeRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function unsubscribe(UnsubscribeRequest $request)
     {
-        $credentials = $request->all();
+        $competition = Competition::find($request->input('competition_id'));
 
-        $competition = Competition::find($credentials['competition_id']);
+        $unsubscribed = $competition->unsubscribe($request->input('northstar_id'));
 
-        // Get competition with activity from flash if it is there.
-        // Otherwise, grab it.
-        $key = generate_model_flash_session_key($competition, ['includeActivity' => true]);
-
-        if (session()->has($key)) {
-            $competition = session($key);
-        } else {
-            $competition = $this->manager->getCompetitionOverview($competition, true, true);
-        }
-
-        $unsubscribed = $competition->unsubscribeUser($credentials['competition_id'], $credentials['northstar_id']);
-
-        if ($unsubscribed == 1) {
+        if ($unsubscribed) {
             return response()->json(['message' =>'success'], 200, [], JSON_UNESCAPED_SLASHES);
         } else {
             return response()->json(['message' =>'error'], 500, [], JSON_UNESCAPED_SLASHES);
         }
-    }
-
-    /**
-     * Create new UnsubscribeController instance.
-     */
-    public function __construct(Manager $manager)
-    {
-        $this->manager = $manager;
-
-        $this->middleware('auth.api');
     }
 }

--- a/app/Http/Controllers/Api/UnsubscribeController.php
+++ b/app/Http/Controllers/Api/UnsubscribeController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Gladiator\Http\Controllers\Api;
+
+use Gladiator\Services\Manager;
+use Gladiator\Models\Competition;
+use Gladiator\Http\Requests\UnsubscribeRequest;
+
+class UnsubscribeController extends ApiController
+{
+    /**
+     * @var Gladiator\Services\Manager;
+     */
+    protected $manager;
+
+    public function unsubscribe(UnsubscribeRequest $request)
+    {
+        $credentials = $request->all();
+
+        $competition = Competition::find($credentials['competition_id']);
+
+        // Get competition with activity from flash if it is there.
+        // Otherwise, grab it.
+        $key = generate_model_flash_session_key($competition, ['includeActivity' => true]);
+
+        if (session()->has($key)) {
+            $competition = session($key);
+        } else {
+            $competition = $this->manager->getCompetitionOverview($competition, true, true);
+        }
+
+        $competition->unsubscribeUser($credentials['competition_id'], $credentials['northstar_id']);
+    }
+
+    /**
+     * Create new UnsubscribeController instance.
+     */
+    public function __construct(Manager $manager)
+    {
+        $this->manager = $manager;
+
+        $this->middleware('auth.api');
+    }
+}

--- a/app/Http/Controllers/Api/UnsubscribeController.php
+++ b/app/Http/Controllers/Api/UnsubscribeController.php
@@ -29,7 +29,13 @@ class UnsubscribeController extends ApiController
             $competition = $this->manager->getCompetitionOverview($competition, true, true);
         }
 
-        $competition->unsubscribeUser($credentials['competition_id'], $credentials['northstar_id']);
+        $unsubscribed = $competition->unsubscribeUser($credentials['competition_id'], $credentials['northstar_id']);
+
+        if ($unsubscribed == 1) {
+            return response()->json(['message' =>'success'], 200, [], JSON_UNESCAPED_SLASHES);
+        } else {
+            return response()->json(['message' =>'error'], 500, [], JSON_UNESCAPED_SLASHES);
+        }
     }
 
     /**

--- a/app/Http/Requests/UnsubscribeRequest.php
+++ b/app/Http/Requests/UnsubscribeRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Gladiator\Http\Requests;
+
+class UnsubscribeRequest extends Request
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        $rules = [
+            'northstar_id' => 'required',
+            'competition_id' => 'required',
+        ];
+
+        return $rules;
+    }
+}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -77,4 +77,6 @@ Route::group(['prefix' => 'api/v1'], function () {
 
     Route::get('users', 'Api\UsersController@index');
     Route::post('users', 'Api\UsersController@store');
+
+    Route::post('unsubscribe', 'Api\UnsubscribeController@unsubscribe');
 });

--- a/app/Models/Competition.php
+++ b/app/Models/Competition.php
@@ -42,9 +42,9 @@ class Competition extends Model
      */
     public function unsubscribe($northstar_id)
     {
-        return DB::table('competitions_users')->where([
+        return DB::table('competition_user')->where([
             ['northstar_id', '=', $northstar_id],
-            ['competition', '=', $this->id],
+            ['competition_id', '=', $this->id],
         ])->update(['unsubscribed' => 1]);
     }
 

--- a/app/Models/Competition.php
+++ b/app/Models/Competition.php
@@ -33,6 +33,14 @@ class Competition extends Model
         return $this->belongsToMany(User::class, 'competition_user', 'competition_id', 'northstar_id')->wherePivot('unsubscribed', '=', 0);
     }
 
+    public function unsubscribeUser($competition_id, $northstar_id)
+    {
+        return $this->belongsToMany(User::class, 'competition_user', 'competition_id', 'northstar_id')
+                    ->wherePivot('competition_id', '=', $competition_id)
+                    ->wherePivot('northstar_id', '=', $northstar_id)
+                    ->update(['unsubscribed' => 1]);
+    }
+
     /**
      * A competition belongs to one contest.
      */

--- a/app/Models/Competition.php
+++ b/app/Models/Competition.php
@@ -2,6 +2,7 @@
 
 namespace Gladiator\Models;
 
+use DB;
 use Illuminate\Database\Eloquent\Model;
 
 class Competition extends Model
@@ -27,18 +28,23 @@ class Competition extends Model
     {
         return $this->belongsToMany(User::class, 'competition_user', 'competition_id', 'northstar_id');
     }
-
+    /**
+     * A Competition has many Subscribers.
+     */
     public function subscribers()
     {
         return $this->belongsToMany(User::class, 'competition_user', 'competition_id', 'northstar_id')->wherePivot('unsubscribed', '=', 0);
     }
 
-    public function unsubscribeUser($competition_id, $northstar_id)
+    /**
+     * Unsubscribe user from Competition.
+     */
+    public function unsubscribe($northstar_id)
     {
-        return $this->belongsToMany(User::class, 'competition_user', 'competition_id', 'northstar_id')
-                    ->wherePivot('competition_id', '=', $competition_id)
-                    ->wherePivot('northstar_id', '=', $northstar_id)
-                    ->update(['unsubscribed' => 1]);
+        return DB::table('competitions_users')->where([
+            ['northstar_id', '=', $northstar_id],
+            ['competition', '=', $this->id],
+        ])->update(['unsubscribed' => 1]);
     }
 
     /**

--- a/app/Models/Competition.php
+++ b/app/Models/Competition.php
@@ -28,6 +28,7 @@ class Competition extends Model
     {
         return $this->belongsToMany(User::class, 'competition_user', 'competition_id', 'northstar_id');
     }
+
     /**
      * A Competition has many Subscribers.
      */


### PR DESCRIPTION
#### What's this PR do?
Creates unsubscribe api endpoint and functionality to expect a competition_id and northstar_id and unsubscribe user from competition_user pivot table

#### How should this be manually tested?
POST to gladiator.dev/api/v1/unsubscribe with a northstar_id, and a competition_id similiar to :
gladiator.dev/api/v1/unsubscribe?northstar_id=5894e9437f43c217dd158b49&competition_id=6
and check local dev to see if that user was unsubscribed (1 value in unsubscribed column in competition_user pivot table)

#### What are the relevant tickets?
Fixes #379 