### PR TITLE
Fixes messages bug where reportback attribute did not exist

### DIFF
--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -527,7 +527,7 @@ class Manager
     {
         $activity = $this->getActivityForUser($user->id, $parameters);
 
-        if ($activity) {
+        if (isset($activity->reportback)) {
             $user->reportback = $activity->reportback;
         } else {
             $user->reportback = null;


### PR DESCRIPTION
#### What's this PR do?
Change conditional value to check if what function will later use exists 

#### How should this be manually tested?
Local or QA-gladiator, go to a competition and click test welcome message 

#### Any background context you want to provide?
what else?

#### What are the relevant tickets??
Fixes similar issue to #380 & #381 , pictures attached



![screen shot 2017-03-28 at 2 43 57 pm](https://cloud.githubusercontent.com/assets/9884758/24422258/e007cbde-13c6-11e7-8710-9fa2e6776d0b.png)

