### PR TITLE
On first session storage of competition overview, correctly grab unsu…

### DIFF
--- a/app/Http/Controllers/CompetitionsController.php
+++ b/app/Http/Controllers/CompetitionsController.php
@@ -58,7 +58,7 @@ class CompetitionsController extends Controller
 
             session()->reflash();
         } else {
-            $competition = $this->manager->getCompetitionOverview($competition, true);
+            $competition = $this->manager->getCompetitionOverview($competition, true, true);
         }
 
         $statistics = $this->manager->getStatisticsForCompetition($competition);
@@ -174,7 +174,7 @@ class CompetitionsController extends Controller
 
             session()->reflash();
         } else {
-            $competition = $this->manager->getCompetitionOverview($competition, true);
+            $competition = $this->manager->getCompetitionOverview($competition, true, true);
 
             session()->flash($key, $competition);
         }
@@ -200,7 +200,7 @@ class CompetitionsController extends Controller
 
             session()->reflash();
         } else {
-            $competition = $this->manager->getCompetitionOverview($competition, true);
+            $competition = $this->manager->getCompetitionOverview($competition, true, true);
 
             session()->flash($key, $competition);
         }
@@ -265,7 +265,7 @@ class CompetitionsController extends Controller
             $competition = session($key);
             session()->reflash();
         } else {
-            $competition = $this->manager->getCompetitionOverview($competition, true);
+            $competition = $this->manager->getCompetitionOverview($competition, true, true);
         }
 
         $leaderboard = $competition->activity['active'];


### PR DESCRIPTION
…bscribed users

#### What's this PR do?
makes sure each function call to get the competition overview in the competitions controller gets the subscribed users as well

#### How should this be manually tested?
Local dev, unsubscribe a user and then check that amount of users corresponds to those subscribed

#### Any background context you want to provide?
what else?

#### What are the relevant tickets?
Fixes #385 