### PR TITLE
Phoenix for activity

### DIFF
--- a/app/Http/Controllers/CompetitionsController.php
+++ b/app/Http/Controllers/CompetitionsController.php
@@ -4,7 +4,6 @@ namespace Gladiator\Http\Controllers;
 
 use Gladiator\Models\User;
 use Illuminate\Http\Request;
-use Gladiator\Models\Contest;
 use Gladiator\Models\Message;
 use Gladiator\Services\Manager;
 use Gladiator\Models\Competition;

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -194,7 +194,7 @@ class Manager
         $parameters['count'] = 25;
 
         // @TODO: Investigat NS proxy; passing a bad ID results in general index of signups response.
-        $signup = $this->northstar->getUserSignups($parameters);
+        $signup = $this->phoenix->getAllSignups($parameters);
 
         return (object) array_shift($signup['data']);
     }
@@ -219,7 +219,7 @@ class Manager
             $parameters['users'] = implode(',', $batch);
             $parameters['count'] = $batchSize;
 
-            $signups = array_merge($signups, $this->northstar->getAllUserSignups($parameters));
+            $signups = array_merge($signups, $this->phoenix->getAllSignups($parameters));
 
             $index += $batchSize;
         }
@@ -482,7 +482,7 @@ class Manager
      */
     protected function appendReportbackToCollection($collection, $parameters)
     {
-        $activity = $this->getActivityForAllUsers($collection->pluck('northstar_id')->all(), $parameters);
+        $activity = $this->getActivityForAllUsers($collection->pluck('id')->all(), $parameters);
 
         $activity = $activity->keyBy(function ($item) {
             return $item['user']['id'];

--- a/app/Services/Phoenix/AuthorizesWithDrupal.php
+++ b/app/Services/Phoenix/AuthorizesWithDrupal.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Gladiator\Services\Phoenix;
+
+use GuzzleHttp\Cookie\CookieJar;
+
+/**
+ * The AuthorizesWithDrupal adds Drupal API auth to a
+ * RestApiClient instance.
+ *
+ * @property \GuzzleHttp\Client $client
+ */
+trait AuthorizesWithDrupal
+{
+    /**
+     * Run custom tasks before making a request.
+     *
+     * @see RestApiClient@raw
+     */
+    protected function runAuthorizesWithDrupalTasks($method, &$path, &$options, &$withAuthorization)
+    {
+        if ($withAuthorization) {
+            $options['cookies'] = $this->getAuthenticationCookie();
+            $options['headers']['X-CSRF-Token'] = $this->getAuthenticationToken();
+        }
+    }
+
+    /**
+     * Returns a token for making authenticated requests to the Drupal API.
+     *
+     * @return array - Cookie & token for authenticated requests
+     */
+    private function authenticate()
+    {
+        $authentication = cache()->remember('drupal.authentication', 30, function () {
+            $response = $this->post('v1/auth/login', [
+                'username' => config('services.phoenix-legacy.username'),
+                'password' => config('services.phoenix-legacy.password'),
+            ], false);
+
+            $session_name = $response['session_name'];
+            $session_value = $response['sessid'];
+
+            return [
+                'cookie' => [$session_name => $session_value],
+                'token' => $response['token'],
+            ];
+        });
+
+        return $authentication;
+    }
+
+    /**
+     * Get the CSRF token for the authenticated API session.
+     *
+     * @return string - token
+     */
+    private function getAuthenticationToken()
+    {
+        return $this->authenticate()['token'];
+    }
+
+    /**
+     * Get the cookie for the authenticated API session.
+     *
+     * @return CookieJar
+     */
+    private function getAuthenticationCookie()
+    {
+        $cookieDomain = parse_url(config('services.phoenix-legacy.url'))['host'];
+
+        return CookieJar::fromArray($this->authenticate()['cookie'], $cookieDomain);
+    }
+}

--- a/app/Services/Phoenix/AuthorizesWithDrupal.php
+++ b/app/Services/Phoenix/AuthorizesWithDrupal.php
@@ -32,10 +32,10 @@ trait AuthorizesWithDrupal
      */
     private function authenticate()
     {
-        $authentication = cache()->remember('drupal.authentication', 30, function () {
+        $authentication = app('cache')->remember('drupal.authentication', 30, function () {
             $response = $this->post('v1/auth/login', [
-                'username' => config('services.phoenix-legacy.username'),
-                'password' => config('services.phoenix-legacy.password'),
+                'username' => config('services.phoenix.username'),
+                'password' => config('services.phoenix.password'),
             ], false);
 
             $session_name = $response['session_name'];
@@ -67,7 +67,7 @@ trait AuthorizesWithDrupal
      */
     private function getAuthenticationCookie()
     {
-        $cookieDomain = parse_url(config('services.phoenix-legacy.url'))['host'];
+        $cookieDomain = parse_url(config('services.phoenix.uri'))['host'];
 
         return CookieJar::fromArray($this->authenticate()['cookie'], $cookieDomain);
     }

--- a/app/Services/Phoenix/Phoenix.php
+++ b/app/Services/Phoenix/Phoenix.php
@@ -6,10 +6,15 @@ use DoSomething\Gateway\Common\RestApiClient;
 
 class Phoenix extends RestApiClient
 {
+    use AuthorizesWithDrupal;
+
+    /*
+     * Phoenix API base uri.
+     */
     protected $base_uri;
 
     /**
-     * Northstar constructor.
+     * Phoenix constructor.
      */
     public function __construct()
     {
@@ -54,5 +59,57 @@ class Phoenix extends RestApiClient
     public function getReportback($reportback_id, $reportback_item_id)
     {
         return $this->get('reportbacks/' . $reportback_id);
+    }
+
+
+    /**
+     * Get an index of (optionally filtered) campaign signups from Phoenix.
+     * @see: https://github.com/DoSomething/phoenix/wiki/API#retrieve-a-signup-collection
+     *
+     * @param array $query - query string, for filtering results
+     * @return array - JSON response
+     */
+    public function getAllSignups(array $query = [])
+    {
+        $path = 'signups';
+
+        // Avoid caching when requesting signups for sepcific user and campaign.
+        // @Temporary?
+        if (isset($query['campaigns']) && isset($query['users'])) {
+            return $this->get($path, $query);
+        }
+
+        return $this->get($path, $query);
+    }
+
+    /**
+     * Get details for a particular campaign signup from Phoenix.
+     * @see: https://github.com/DoSomething/phoenix/wiki/API#retrieve-a-specific-signup
+     *
+     * @return array - JSON response
+     */
+    public function getSignup($signup_id)
+    {
+        $path = 'signups/'.$signup_id;
+
+        return $this->get($path);
+    }
+
+    /**
+     * Get an index of (optionally filtered) campaign reportbacks from Phoenix.
+     * @see: https://github.com/DoSomething/phoenix/wiki/API#retrieve-a-reportback-collection
+     *
+     * @param array|string $query - query string, for filtering results
+     * @return array - JSON response
+     */
+    public function getAllReportbacks(array $query = [])
+    {
+        $path = 'reportbacks';
+        $query['load_user'] = true;
+        if (auth()->id()) {
+            $query['as_user'] = auth()->id();
+        }
+
+        return $this->get($path, $query);
     }
 }

--- a/app/Services/Phoenix/Phoenix.php
+++ b/app/Services/Phoenix/Phoenix.php
@@ -61,7 +61,6 @@ class Phoenix extends RestApiClient
         return $this->get('reportbacks/' . $reportback_id);
     }
 
-
     /**
      * Get an index of (optionally filtered) campaign signups from Phoenix.
      * @see: https://github.com/DoSomething/phoenix/wiki/API#retrieve-a-signup-collection

--- a/config/services.php
+++ b/config/services.php
@@ -43,6 +43,8 @@ return [
     'phoenix' => [
         'uri' => env('PHOENIX_URI'),
         'version' => env('PHOENIX_API_VERSION'),
+        'username' => env('PHOENIX_USERNAME'),
+        'password' => env('PHOENIX_PASSWORD'),
     ],
 
     'ses' => [


### PR DESCRIPTION
#### What's this PR do?

Switches calls to the northstar `/signups` proxy to calls directly to the phoenix API to grab user activity. 

#### How should this be manually tested?

You can review this PR commit by commit. The `AuthorizesWithDrupal` Trait and the added `Phoenix` service methods are borrowed (copied 😬 ) from Phoenix-next

We will have to do more thorough testing on QA and prod which have more users with activity. 

#### What are the relevant tickets?
Fixes #388 