### PR TITLE
Leaderboard bug

### DIFF
--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -77,23 +77,23 @@ class Manager
             ];
 
             if (isset($user->reportback)) {
-                $details[] = reportback_admin_url($user->reportback->id);
-                $details[] = $user->reportback->quantity;
-                $details[] = $user->reportback->reportback_items->count_by_status['promoted'];
-                $details[] = $user->reportback->reportback_items->count_by_status['approved'];
-                $details[] = $user->reportback->reportback_items->count_by_status['excluded'];
-                $details[] = $user->reportback->reportback_items->count_by_status['flagged'];
-                $details[] = $user->reportback->reportback_items->count_by_status['pending'];
-                $details[] = $user->reportback->why_participated;
+                $details[] = reportback_admin_url($user->reportback['id']);
+                $details[] = $user->reportback['quantity'];
+                $details[] = $user->reportback['reportback_items']['count_by_status']['promoted'];
+                $details[] = $user->reportback['reportback_items']['count_by_status']['approved'];
+                $details[] = $user->reportback['reportback_items']['count_by_status']['excluded'];
+                $details[] = $user->reportback['reportback_items']['count_by_status']['flagged'];
+                $details[] = $user->reportback['reportback_items']['count_by_status']['pending'];
+                $details[] = $user->reportback['why_participated'];
 
-                $filteredReportbacks = $this->getStatus($user->reportback->reportback_items->data, 'pending');
-                $latestReportBackItem = array_pop($user->reportback->reportback_items->data);
+                $filteredReportbacks = $this->getStatus($user->reportback['reportback_items']['data'], 'pending');
+                $latestReportBackItem = array_pop($user->reportback['reportback_items']['data']);
 
-                $details[] = $latestReportBackItem->caption;
-                $details[] = date('m/d/Y H:i', $latestReportBackItem->created_at);
+                $details[] = $latestReportBackItem['caption'];
+                $details[] = date('m/d/Y H:i', $latestReportBackItem['created_at']);
 
                 if (! is_null($filteredReportbacks)) {
-                    $details[] = array_pop($filteredReportbacks)->media->uri;
+                    $details[] = array_pop($filteredReportbacks)['media']['uri'];
                 }
             }
 
@@ -116,7 +116,7 @@ class Manager
         $list = [];
 
         foreach ($data as $reportbackitem) {
-            if ($reportbackitem->status == $status) {
+            if ($reportbackitem['status'] == $status) {
                 $list[] = $reportbackitem;
             }
         }

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -116,7 +116,7 @@ class Manager
         $list = [];
 
         foreach ($data as $reportbackitem) {
-            if ($reportbackitem['status'] == $status) {
+            if ($reportbackitem['status'] === $status) {
                 $list[] = $reportbackitem;
             }
         }

--- a/resources/views/competitions/partials/_table_users_leaderboard.blade.php
+++ b/resources/views/competitions/partials/_table_users_leaderboard.blade.php
@@ -22,14 +22,12 @@
                         <tr class="table__row">
                             <td class="table__cell">{{ $user->rank }}</td>
                             <td class="table__cell"><a href="{{ route('users.show', $user->id) }}" target="_blank">{{ $user->first_name or 'Anonymous' }} {{ $user->last_initial or '' }}</a></td>
-                            {{-- <td class="table__cell">{{ $user->email or '' }}</td> --}}
-                            <td class="table__cell">{{ $user->reportback->quantity or 'n/a' }}</td>
-                            <td class="table__cell">{{ $user->reportback->reportback_items->count_by_status['promoted'] or 'n/a' }}</td>
-                            <td class="table__cell">{{ $user->reportback->reportback_items->count_by_status['approved'] or 'n/a' }}</td>
-                            <td class="table__cell">{{ $user->reportback->reportback_items->count_by_status['excluded'] or 'n/a' }}</td>
-                            <td class="table__cell">{{ $user->reportback->reportback_items->count_by_status['flagged'] or 'n/a' }}</td>
-                            <td class="table__cell">{{ $user->reportback->reportback_items->count_by_status['pending'] or 'n/a' }}</td>
-                        </tr>
+                            <td class="table__cell">{{ $user->reportback['quantity'] or 'n/a' }}</td>
+                            <td class="table__cell">{{ $user->reportback['reportback_items']['count_by_status']['promoted'] or 'n/a' }}</td>
+                            <td class="table__cell">{{ $user->reportback['reportback_items']['count_by_status']['approved'] or 'n/a' }}</td>
+                            <td class="table__cell">{{ $user->reportback['reportback_items']['count_by_status']['excluded'] or 'n/a' }}</td>
+                            <td class="table__cell">{{ $user->reportback['reportback_items']['count_by_status']['flagged'] or 'n/a' }}</td>
+                            <td class="table__cell">{{ $user->reportback['reportback_items']['count_by_status']['pending'] or 'n/a' }}</td>
                     @endforeach
                 </tbody>
             </table>


### PR DESCRIPTION
#### What's this PR do?

Now that we are getting user activity directly from phoenix, the data gets returned to us with embedded arrays instead of objects. This changes how we pull in the data to the leaderboard view and the leaderboard export. 

This PR updates the code so that we pull in the data accessing the arrays, instead of trying to use objects. 

#### How should this be manually tested?

* Go to a leaderboard and you should see the data in the view instead of `N/A`.
* Try to export a leaderboard and it should export properly without throwing errors that you are trying to get a property of a non-object. 

#### What are the relevant tickets?
Fixes #392 