### PR TITLE
Search bug

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -186,7 +186,7 @@ class UsersController extends Controller
         }
 
         // Attempt to fetch all users.
-        $users = $this->manager->search($query);
+        $users = $this->registrar->search($query);
 
         if (! $users) {
             return redirect()->route('users.index')->with('status', 'No user found!');

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -606,27 +606,4 @@ class Manager
             return null;
         }
     }
-
-    /**
-     * Search for users in Northstar.
-     *
-     * @param  string $query
-     * @param  int $page
-     * @return collection|null
-     */
-    public function search($query, $page = null)
-    {
-        // Attempt to fetch all users.
-        $users = $this->northstar->getAllUsers([
-            'search' => [
-                '_id' => $query,
-                'drupal_id' => $query,
-                'email' => $query,
-                'mobile' => $query,
-            ],
-            'page' => is_null($page) ? 1 : $page,
-        ]);
-
-        return $users ? collect($users) : null;
-    }
 }

--- a/app/Services/Registrar.php
+++ b/app/Services/Registrar.php
@@ -84,4 +84,27 @@ class Registrar
 
         return $user;
     }
+
+    /**
+     * Search for users in Northstar.
+     *
+     * @param  string $query
+     * @param  int $page
+     * @return collection|null
+     */
+    public function search($query, $page = null)
+    {
+        // Attempt to fetch all users.
+        $users = $this->northstar->getAllUsers([
+            'search' => [
+                '_id' => $query,
+                'drupal_id' => $query,
+                'email' => $query,
+                'mobile' => $query,
+            ],
+            'page' => is_null($page) ? 1 : $page,
+        ]);
+
+        return $users ? collect($users) : null;
+    }
 }


### PR DESCRIPTION
#### What's this PR do?

Search functionality was breaking because we were still trying to use the custom `Northstar` service we built for this app instead of the shared `Northstar` service in Gateway. 

Since this is actually user functionality, I moved the `search()` method that makes the Northstar call into the `Registrar` service, which is properly using Gateway Northstar and changed the call to this method to use the new Registrar method.

#### How should this be manually tested?

Go to the users page and try to search for someone. If found, you should be taken to that user's individual page instead of an error being thrown.

#### What are the relevant tickets?
Fixes #393 