### PR TITLE
Make sure all activity is showing in leaderboard/competition stats

### DIFF
--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -219,12 +219,14 @@ class Manager
             $parameters['users'] = implode(',', $batch);
             $parameters['count'] = $batchSize;
 
-            $signups = array_merge($signups, $this->phoenix->getAllSignups($parameters));
+            $batchSignups = $this->phoenix->getAllSignups($parameters);
+
+            $signups = array_merge($signups, $batchSignups['data']);
 
             $index += $batchSize;
         }
 
-        return collect($signups['data']);
+        return collect($signups);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?

This PR fixes a bug where users with activity were not being included in the leaderboard or counted in the competition stats.

The issue was introduced when we moved to using the phoenix API directly instead of using the northstar proxy to grab signup data.

Phoenix returns data in an array with `meta` and `data` properties. We were grabbing signups by batches, and then trying to create a larger array of all the signup data with `array_merge` but we were not specifying that we needed the larger array to use the `data` property that had all the actual signup information. 

This updates the code so that we return the correct data to the services that are trying to catalog and calculate leardboard info.

#### What are the relevant tickets?
Fixes #397 