### PR TITLE
Returns an empty array if the user does not exist in gladiator

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -57,6 +57,10 @@ class UsersController extends ApiController
     {
         $user = User::find($request['id']);
 
+        if (is_null($user)) {
+            return response()->json([]);
+        }
+
         $contest = $this->getContest($request['campaign_id'], $request['campaign_run_id']);
 
         if ($contest) {


### PR DESCRIPTION
#### What's this PR do?
Added logic that if a user is not found in gladiator, return an empty array

#### How should this be manually tested?
Issue a GET request to to api/v1/users with parameters `id` , `campaign_id`, and `campaign_run_id` where id is not a user that exists in gladiator. You should get an empty array back.