### PR TITLE
Add env variable, and new unsubscribe link token

### DIFF
--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -87,6 +87,7 @@ class Email
             ':sender_name:'           => $this->contest->sender_name,
             ':rules_url:'             => ! is_null($this->competition) ? $this->competition->rules_url : '',
             ':share_link:'            => url(config('services.phoenix.uri') .'/us/node/' . $this->contest->campaign_id . '?source=user/' . $user->id),
+            ':unsubscribe_link:'      => url(config('services.northstar.profile_url') . '/unsubscribe?' . 'northstar_id='.$user->id . '&competition_id=' . $this->competition->id),
         ];
 
         return $tokens;

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -87,7 +87,7 @@ class Email
             ':sender_name:'           => $this->contest->sender_name,
             ':rules_url:'             => ! is_null($this->competition) ? $this->competition->rules_url : '',
             ':share_link:'            => url(config('services.phoenix.uri') .'/us/node/' . $this->contest->campaign_id . '?source=user/' . $user->id),
-            ':unsubscribe_link:'      => url((config('services.northstar.profile_url') . '/unsubscribe?' .http_build_query(['northstar_id' => $user->id, 'competition_id' => $this->competition->id]))),
+            ':unsubscribe_link:'      => url((config('services.northstar.profile_url') . '/unsubscribe?' . http_build_query(['northstar_id' => $user->id, 'competition_id' => $this->competition->id]))),
         ];
 
         return $tokens;

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -87,7 +87,9 @@ class Email
             ':sender_name:'           => $this->contest->sender_name,
             ':rules_url:'             => ! is_null($this->competition) ? $this->competition->rules_url : '',
             ':share_link:'            => url(config('services.phoenix.uri') .'/us/node/' . $this->contest->campaign_id . '?source=user/' . $user->id),
-            ':unsubscribe_link:'      => url(config('services.northstar.profile_url') . '/unsubscribe?' . 'northstar_id='.$user->id . '&competition_id=' . $this->competition->id),
+            ':unsubscribe_link:'      => url((config('services.northstar.profile_url') . '/unsubscribe?' .http_build_query(['northstar_id' => $user->id, 'competition_id' => $this->competition->id]))),
+
+            //url(config('services.northstar.profile_url') . '/unsubscribe?' . 'northstar_id='.$user->id . '&competition_id=' . $this->competition->id),
         ];
 
         return $tokens;

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -88,8 +88,6 @@ class Email
             ':rules_url:'             => ! is_null($this->competition) ? $this->competition->rules_url : '',
             ':share_link:'            => url(config('services.phoenix.uri') .'/us/node/' . $this->contest->campaign_id . '?source=user/' . $user->id),
             ':unsubscribe_link:'      => url((config('services.northstar.profile_url') . '/unsubscribe?' .http_build_query(['northstar_id' => $user->id, 'competition_id' => $this->competition->id]))),
-
-            //url(config('services.northstar.profile_url') . '/unsubscribe?' . 'northstar_id='.$user->id . '&competition_id=' . $this->competition->id),
         ];
 
         return $tokens;

--- a/config/services.php
+++ b/config/services.php
@@ -29,6 +29,7 @@ return [
             'scope' => ['user', 'role:staff', 'role:admin'],
             'redirect_uri' => '/login',
         ],
+        'profile_url' => env('NORTHSTAR_PROFILE_URL'),
     ],
 
     'mailgun' => [


### PR DESCRIPTION
#### What's this PR do?
Added token for Email's being sent in gladiator to include unsubscribe_link crafted with users id and competition id.

#### How should this be manually tested?
Send a test message and check if :unsubscribe_link: is properly replaced.

#### What are the relevant tickets?
Ongoing progress to create unsubscribe link in gladiator 