### PR TITLE
Leaderboard messages bug

### DIFF
--- a/app/Http/Controllers/CompetitionsController.php
+++ b/app/Http/Controllers/CompetitionsController.php
@@ -273,7 +273,7 @@ class CompetitionsController extends Controller
         $photos = [];
 
         foreach ($topThree as $key => $user) {
-            $photos[] = LeaderboardPhoto::where('competition_id', '=', $competition->id)->where('message_id', '=', $message->id)->where('user_id', '=', $user['user_id'])->first();
+            $photos[] = LeaderboardPhoto::where('competition_id', '=', $competition->id)->where('message_id', '=', $message->id)->where('northstar_id', '=', $user['northstar_id'])->first();
         }
 
         return view('competitions.leaderboard_photos.edit', compact('competition', 'message', 'photos', 'topThree'));

--- a/app/Repositories/DatabaseUserRepository.php
+++ b/app/Repositories/DatabaseUserRepository.php
@@ -48,7 +48,7 @@ class DatabaseUserRepository implements UserRepositoryContract
     {
         $user = User::findOrFail($id);
 
-        $account = $this->northstar->getUser('_id', $user->northstar_id);
+        $account = $this->northstar->getUser('id', $user->northstar_id);
 
         if ($account) {
             $account->role = $user->role;

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -377,13 +377,13 @@ class Manager
               'place' => $places[$key],
               'first_name' => $user->first_name,
               'prize_copy' => $prizeCopy[$key],
-              'quantity' => $user->reportback->quantity,
+              'quantity' => $user->reportback['quantity'],
             ];
 
             // Provide info on user & reportback ids
             if (isset($options['includeUserIds']) && $options['includeUserIds']) {
                 $topThree[$key]['northstar_id'] = $user->northstar_id;
-                $topThree[$key]['reportback_id'] = $user->reportback->id;
+                $topThree[$key]['reportback_id'] = $user->reportback['id'];
             }
 
             // Provide image url/captaion of top three leaderboard images
@@ -391,12 +391,12 @@ class Manager
                 $leaderboardReportbackItem = $this->getLeaderboardPhoto($options['competition_id'], $options['message_id'], $user->northstar_id);   //@NOTE calling Phoenix again
 
                 if (! isset($leaderboardReportbackItem)) {
-                    $reportbackItems = $user->reportback->reportback_items->data;
+                    $reportbackItems = $user->reportback['reportback_items']['data'];
                     $leaderboardReportbackItem = array_pop($reportbackItems);
                 }
 
-                $topThree[$key]['image_url'] = $leaderboardReportbackItem->media->uri;
-                $topThree[$key]['caption'] = $leaderboardReportbackItem->caption;
+                $topThree[$key]['image_url'] = $leaderboardReportbackItem['media']['uri'];
+                $topThree[$key]['caption'] = $leaderboardReportbackItem['caption'];
             }
         }
 
@@ -416,7 +416,7 @@ class Manager
             return;
         }
 
-        $leaderboardPhoto = LeaderboardPhoto::where('competition_id', '=', $competitionId)->where('message_id', '=', $messageId)->where('user_id', '=', $userId)->first();
+        $leaderboardPhoto = LeaderboardPhoto::where('competition_id', '=', $competitionId)->where('message_id', '=', $messageId)->where('nortstar_id', '=', $userId)->first();
 
         if (isset($leaderboardPhoto) && isset($leaderboardPhoto->reportback_id) && isset($leaderboardPhoto->reportback_item_id)) {
             $reportbackItem = $this->appendReportbackItemToMessage($leaderboardPhoto->reportback_id, $leaderboardPhoto->reportback_item_id);

--- a/app/Services/Manager.php
+++ b/app/Services/Manager.php
@@ -382,7 +382,7 @@ class Manager
 
             // Provide info on user & reportback ids
             if (isset($options['includeUserIds']) && $options['includeUserIds']) {
-                $topThree[$key]['northstar_id'] = $user->northstar_id;
+                $topThree[$key]['northstar_id'] = $user->id;
                 $topThree[$key]['reportback_id'] = $user->reportback['id'];
             }
 
@@ -416,7 +416,7 @@ class Manager
             return;
         }
 
-        $leaderboardPhoto = LeaderboardPhoto::where('competition_id', '=', $competitionId)->where('message_id', '=', $messageId)->where('nortstar_id', '=', $userId)->first();
+        $leaderboardPhoto = LeaderboardPhoto::where('competition_id', '=', $competitionId)->where('message_id', '=', $messageId)->where('northstar_id', '=', $userId)->first();
 
         if (isset($leaderboardPhoto) && isset($leaderboardPhoto->reportback_id) && isset($leaderboardPhoto->reportback_item_id)) {
             $reportbackItem = $this->appendReportbackItemToMessage($leaderboardPhoto->reportback_id, $leaderboardPhoto->reportback_item_id);

--- a/resources/views/competitions/leaderboard_photos/edit.blade.php
+++ b/resources/views/competitions/leaderboard_photos/edit.blade.php
@@ -20,9 +20,9 @@
                     @foreach ($topThree as $index => $reportback)
                     <div class="form-item -padded">
                         <h2>{{$reportback['place']}} Place: {{$reportback['first_name']}}</h2>
-                        <label class="field-label" for="user_id_{{$index}}">User ID: </label>
-                        <label>{{ $reportback['user_id']}}</label>
-                        <input type="text" name="user_id_{{$index}}" id="user_id_{{$index}}" class="text-field" value="{{ $reportback['user_id']}}" hidden/>
+                        <label class="field-label" for="northstar_id_{{$index}}">Northstar ID: </label>
+                        <label>{{ $reportback['northstar_id']}}</label>
+                        <input type="text" name="northstar_id_{{$index}}" id="northstar_id_{{$index}}" class="text-field" value="{{ $reportback['northstar_id']}}" hidden/>
                     </div>
 
                     <div class="form-item -padded">


### PR DESCRIPTION
#### What's this PR do?

Makes updates to how we grab the info needed to generate the leaderboard photos for leaderboard messages. 

There seemed to be a bug with sending the leaderboard messages for the Sincerly, Us campaign. It seemed to be related to not grabbing the reportback item data correctly now that we use Phoenix to grab the data and it returns data as nested arrays. These fixes were able to get messages to send on my local. 

The odd thing about this bug is that it just popped up on this campaign, going to dig further into why. 

#### What are the relevant tickets?
Fixes #407