### PR TITLE
Display user info in leaderboard messages

### DIFF
--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -196,11 +196,27 @@ class Email
     {
         $leaderboard = $this->competition->activity['active'];
 
+        // @TEMP - Convert the NorthstarUser objects that make up the leaderboard array into smaller arrays with just the information we need to display in the email. This is a hacky way of getting around an issue where we can't pass serialized objects to the message view through the mail queue.
+        $entryArray = [];
+
+        foreach ($leaderboard as $user) {
+            $entry = [];
+
+            $entry = [
+                'first_name' => $user->first_name,
+                'last_initial' => $user->last_initial,
+                'rank' => $user->rank,
+                'quantity' => $user->reportback['quantity'],
+            ];
+
+            $entryArray[] = $entry;
+        }
+
         $vars = [];
 
         if ($leaderboard) {
             $vars = [
-                'leaderboard' => $leaderboard,
+                'leaderboard' => $entryArray,
                 'topThree' => $this->manager->getTopThreeReportbacks($leaderboard, ['competition_id' => $this->competition->id, 'message_id' => $this->message->id]),
                 'reportbackInfo' => $this->contest->campaign->reportback_info,
                 'featuredReportback' => $this->getFeaturedReportback(),

--- a/resources/views/messages/partials/_leaderboard_table.blade.php
+++ b/resources/views/messages/partials/_leaderboard_table.blade.php
@@ -13,7 +13,7 @@
             <tr class="table__row">
                 <td class="table__cell" style="border-bottom: 1px solid #ddd; padding: 10px 10px 10px 0px; text-align: left;">{{ $user['rank'] }}</td>
                 <td class="table__cell" style="border-bottom: 1px solid #ddd; padding: 10px 10px 10px 0px; text-align: left;">{{ $user['first_name'] or 'Anonymous' }} {{ $user['last_initial'] or '' }}</td>
-                <td class="table__cell" style="border-bottom: 1px solid #ddd; padding: 10px 10px 10px 0px; text-align: left;">{{ $user['reportback']['quantity'] or 'n/a' }}</td>
+                <td class="table__cell" style="border-bottom: 1px solid #ddd; padding: 10px 10px 10px 0px; text-align: left;">{{ $user['quantity'] or 'n/a' }}</td>
             </tr>
         @endforeach
     </tbody>


### PR DESCRIPTION
#### What's this PR do?

In #408, we fixed and issue sending leaderboard messages. However there still seemed to be an issue with the content of the message not pulling in the user names to the leaderboard. Example: 

![image](https://cloud.githubusercontent.com/assets/1700409/25873280/e4ec9964-34db-11e7-974a-b19de273ae7c.png)

I am not fully sure when this was introduced, but it seems it might have been introduced when we started using Gateway for making calls to northstar. These calls return `NorthstarUser` objects, which we then appended activity to and cataloged for the leaderboard. Essentialy the `leaderboard` variable we sent to the message view was full of `NorthstarUser`objects. 

We are using Mail Queues to send these message, and queues do not allow objects to be passed to the view, it converts them to arrays, and it was stripping the `NorthstarUser` data when it did that. 

The work around I came up with was to just create a smaller array with only the data we needed to use to display in the leaderboard. It's not pretty and, it's a bit of a hack. Going to try to schedule some time into my next sprint to clean some of this stuff up. 

Leaderboard messages now: 

![image](https://cloud.githubusercontent.com/assets/1700409/25873515/d8f2c150-34dc-11e7-8e44-05c6e925df54.png)

#### How should this be manually tested?

We need to deploy to QA and TESSST

#### What are the relevant tickets?
Addresses #408 