### PR TITLE
Remove unsubscribe link from welcome

### DIFF
--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -106,7 +106,10 @@ class Email
         $processedMessage['type'] = $message->type;
         $processedMessage['key'] = $message->key;
         $processedMessage['show_images'] = $message->show_images;
-        $processedMessage['unsubscribe_link'] = url((config('services.northstar.profile_url') . '/unsubscribe?' . http_build_query(['northstar_id' => $user->id, 'competition_id' => $this->competition->id])));
+
+        if ($message->type !== 'welcome' &&  $this->competition->id) {
+            $processedMessage['unsubscribe_link'] = url((config('services.northstar.profile_url') . '/unsubscribe?' . http_build_query(['northstar_id' => $user->id, 'competition_id' => $this->competition->id])));
+        }
 
         foreach ($parsableProperties as $prop) {
             $processedMessage[$prop] = $this->replaceTokens($tokens, $message->$prop);

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -87,7 +87,6 @@ class Email
             ':sender_name:'           => $this->contest->sender_name,
             ':rules_url:'             => ! is_null($this->competition) ? $this->competition->rules_url : '',
             ':share_link:'            => url(config('services.phoenix.uri') .'/us/node/' . $this->contest->campaign_id . '?source=user/' . $user->id),
-            ':unsubscribe_link:'      => url((config('services.northstar.profile_url') . '/unsubscribe?' . http_build_query(['northstar_id' => $user->id, 'competition_id' => $this->competition->id]))),
         ];
 
         return $tokens;

--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -107,7 +107,7 @@ class Email
         $processedMessage['key'] = $message->key;
         $processedMessage['show_images'] = $message->show_images;
 
-        if ($message->type !== 'welcome' &&  $this->competition->id) {
+        if ($message->type !== 'welcome' && $this->competition->id) {
             $processedMessage['unsubscribe_link'] = url((config('services.northstar.profile_url') . '/unsubscribe?' . http_build_query(['northstar_id' => $user->id, 'competition_id' => $this->competition->id])));
         }
 

--- a/resources/views/messages/welcome.blade.php
+++ b/resources/views/messages/welcome.blade.php
@@ -1,3 +1,1 @@
 <p>{!! $content['body'] !!}</p>
-
-<p>Don’t want to receive emails about this competition? <a href="{{ $content['unsubscribe_link'] }}">Unsubscribe</a></p>


### PR DESCRIPTION
#### What's this PR do?

This removes the unsubscribe link from welcome emails. Building the email was failing because there was no competition to unsubscribe from when a user first enters a waiting room. 

#### How should this be manually tested?

Send yourself a test welcome message and all should be gravy. 

#### Any background context you want to provide?

We will be updating the unsubscribe logic to also unsubscribe people who are just in waiting rooms. This fixes the issue in the meantime. 
