### PR TITLE
only show top 100 in email

### DIFF
--- a/app/Services/Email.php
+++ b/app/Services/Email.php
@@ -201,6 +201,8 @@ class Email
     {
         $leaderboard = $this->competition->activity['active'];
 
+        $leaderboard = array_slice($leaderboard, 0, 100);
+
         // @TEMP - Convert the NorthstarUser objects that make up the leaderboard array into smaller arrays with just the information we need to display in the email. This is a hacky way of getting around an issue where we can't pass serialized objects to the message view through the mail queue.
         $entryArray = [];
 


### PR DESCRIPTION
#### What's this PR do?

Slices the leaderboard to the top 100 folks before rendering it in the email. 

#### How should this be manually tested?

Send a leaderboard and you should only see the top 100 in the email. 

#### Any background context you want to provide?

I originally thought this would help with some performances bottlenecks that happen when trying to grab large amount of RB data for a large set of users. But that was stupid because we still need all the user activity to calculate who is in the top 100 

![image](https://user-images.githubusercontent.com/1700409/29044212-67445c0c-7b8c-11e7-97af-c9975794022c.png)

Regardless, it does seem really heavy to put the full leaderboard, that is sometimes over 1k people, in one email, so I think chopping it makes sense for the user experience anyway. 

#### What are the relevant tickets?

Addresses https://www.pivotaltracker.com/story/show/149209601