### PR TITLE
Limit contest response

### DIFF
--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -103,7 +103,7 @@ class ApiController extends BaseController
             $transformer = $this->transformer;
         }
 
-        $pages = (int) $request->query('limit', 20);
+        $pages = (int) $request->query('limit', 1);
         $paginator = $query->paginate(min($pages, 100));
 
         $queryParams = array_diff_key($request->query(), array_flip(['page']));

--- a/app/Http/Transformers/CompetitionTransformer.php
+++ b/app/Http/Transformers/CompetitionTransformer.php
@@ -24,7 +24,6 @@ class CompetitionTransformer extends TransformerAbstract
             'leaderboard_msg_day' => jddayofweek($competition->leaderboard_msg_day, 1),
             'rules' => $competition->rules_url,
             'users' => $competition->users->pluck('northstar_id'),
-            'subscribed_users' => $competition->subscribers->pluck('northstar_id'),
             'unsubscribed_users' => $competition->unsubscribers->pluck('northstar_id'),
             'created_at' => $competition->created_at->toIso8601String(),
             'updated_at' => $competition->updated_at->toIso8601String(),


### PR DESCRIPTION
#### What's this PR do?

We ran into some timeout issues on gladiator related to hitting the new `/api/v2/contests` endpoint. I believe the issue is due to the heavy payload we are trying to return to the client. For example, we defaulted to 20 contests per page, each contest could have a 5+ competitions, each competition could have 1k+ contestants in it. Another thing we were doing were returning overall users in the competition plus an array of subscribers (similar in size to contestants) plus an array of unsubscribers (smaller in size). 

This PR does two things

* Limit the results to 1 contest per page, be default, the client can still ask for more, but the request will probably timeout. 
* Remove the `subscribers` property, which means the client would have to do it's own logic to determine who is subscribed based on the full set of users in competitions and the set of unsubscribed users/

#### How should this be manually tested?

hit `GET /api/v2/contests` and make sure you only get one per page. 

#### Any background context you want to provide?
See above

#### What are the relevant tickets?
Fixes 🐛 