### PR TITLE
Fix contest and user seeders

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -33,8 +33,8 @@ $factory->define(Contest::class, function (Generator $faker) {
     $campaign = $phoenix->getCampaign($campaignIds[array_rand($campaignIds)]);
 
     return [
-        'campaign_id' => $campaign->id,
-        'campaign_run_id' => $campaign->campaign_runs->current->en->id,
+        'campaign_id' => $campaign['data']['id'],
+        'campaign_run_id' => $campaign['data']['campaign_runs']['current']['en']['id'],
         'sender_email' => $faker->safeEmail(),
         'sender_name' => $faker->name(),
     ];

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -3,8 +3,8 @@
 use Gladiator\Models\User;
 use Illuminate\Database\Seeder;
 use Gladiator\Models\WaitingRoom;
+use DoSomething\Gateway\Northstar;
 use Illuminate\Support\Facades\Artisan;
-use Gladiator\Services\Northstar\Northstar;
 
 class UserTableSeeder extends Seeder
 {


### PR DESCRIPTION
#### What's this PR do?

We are getting back a campaign array, not an object, from the phoenix API and when we tried to access the object properties to seed the DB we were getting error. 

Also we are using the `Northstar` class from Gateway to see users now. 

#### How should this be manually tested?
Run migrations, run seeders, things should run fine. 

#### What are the relevant tickets?
Fixes 🐛 