### PR TITLE
Return more specific error messages

### DIFF
--- a/app/Http/Controllers/Api/UnsubscribeController.php
+++ b/app/Http/Controllers/Api/UnsubscribeController.php
@@ -26,7 +26,7 @@ class UnsubscribeController extends ApiController
     {
         $query = DB::table('competition_user')->where([
             ['northstar_id', '=', $request->input('northstar_id')],
-            ['competition_id', '=', $request->input('competition_id')]
+            ['competition_id', '=', $request->input('competition_id')],
         ]);
 
         if (!$query->first()) {

--- a/app/Http/Controllers/Api/UnsubscribeController.php
+++ b/app/Http/Controllers/Api/UnsubscribeController.php
@@ -2,6 +2,7 @@
 
 namespace Gladiator\Http\Controllers\Api;
 
+use DB;
 use Gladiator\Models\Competition;
 use Gladiator\Http\Requests\UnsubscribeRequest;
 
@@ -23,14 +24,19 @@ class UnsubscribeController extends ApiController
      */
     public function unsubscribe(UnsubscribeRequest $request)
     {
-        $competition = Competition::find($request->input('competition_id'));
+        $query = DB::table('competition_user')->where([
+            ['northstar_id', '=', $request->input('northstar_id')],
+            ['competition_id', '=', $request->input('competition_id')]
+        ]);
 
-        $unsubscribed = $competition->unsubscribe($request->input('northstar_id'));
-
-        if ($unsubscribed) {
-            return response()->json(['message' =>'success'], 200, [], JSON_UNESCAPED_SLASHES);
+        if (!$query->first()) {
+            return response()->json(['message' => 'There was an error processing that request.'], 500, [], JSON_UNESCAPED_SLASHES);
+        } elseif ($query->first()->unsubscribed) {
+            return response()->json(['message' => 'User already unsubscribed'], 422, [], JSON_UNESCAPED_SLASHES);
         } else {
-            return response()->json(['message' =>'error'], 500, [], JSON_UNESCAPED_SLASHES);
+            $query->update(['unsubscribed' => 1]);
+
+            return response()->json(['message' => 'success'], 200, [], JSON_UNESCAPED_SLASHES);
         }
     }
 }

--- a/app/Http/Controllers/Api/UnsubscribeController.php
+++ b/app/Http/Controllers/Api/UnsubscribeController.php
@@ -29,7 +29,7 @@ class UnsubscribeController extends ApiController
             ['competition_id', '=', $request->input('competition_id')],
         ]);
 
-        if (!$query->first()) {
+        if (! $query->first()) {
             return response()->json(['message' => 'There was an error processing that request.'], 500, [], JSON_UNESCAPED_SLASHES);
         } elseif ($query->first()->unsubscribed) {
             return response()->json(['message' => 'User already unsubscribed'], 422, [], JSON_UNESCAPED_SLASHES);

--- a/app/Models/Competition.php
+++ b/app/Models/Competition.php
@@ -2,7 +2,6 @@
 
 namespace Gladiator\Models;
 
-use DB;
 use Illuminate\Database\Eloquent\Model;
 
 class Competition extends Model
@@ -43,17 +42,6 @@ class Competition extends Model
     public function unsubscribers()
     {
         return $this->belongsToMany(User::class, 'competition_user', 'competition_id', 'northstar_id')->wherePivot('unsubscribed', '=', 1);
-    }
-
-    /**
-     * Unsubscribe user from Competition.
-     */
-    public function unsubscribe($northstar_id)
-    {
-        return DB::table('competition_user')->where([
-            ['northstar_id', '=', $northstar_id],
-            ['competition_id', '=', $this->id],
-        ])->update(['unsubscribed' => 1]);
     }
 
     /**

--- a/app/Services/Catalog.php
+++ b/app/Services/Catalog.php
@@ -96,8 +96,8 @@ class Catalog
                 // If the last row quantity equals this rows quantity, just increment.
                 if ($user->reportback['quantity'] === $users[$index - 1]->reportback['quantity']) {
                     $increment++;
-                // Otherwise apply the increment to the rank and reset it back to 1.
                 } else {
+                // Otherwise apply the increment to the rank and reset it back to 1.
                     $rank += $increment;
                     $increment = 1;
                 }

--- a/app/Services/Catalog.php
+++ b/app/Services/Catalog.php
@@ -97,7 +97,7 @@ class Catalog
                 if ($user->reportback['quantity'] === $users[$index - 1]->reportback['quantity']) {
                     $increment++;
                 } else {
-                // Otherwise apply the increment to the rank and reset it back to 1.
+                    // Otherwise apply the increment to the rank and reset it back to 1.
                     $rank += $increment;
                     $increment = 1;
                 }


### PR DESCRIPTION
#### What's this PR do?
Updates the unsubscribe API response so that it sends better response codes/messages if a user is already subscribed. 

#### How should this be manually tested?
Try to unsubscribe from a competition that you are already unsubscribe from, and you should receive a `422` error. 

#### Any background context you want to provide?

On the northstar side, when users unsubscribe and they are already unsubscribed from a competition, they receive an error message that says "There was an error processing your request." That led us to think there was something wrong with the functionality, but it seems to be working fine, except that we don't make it clear to the user that they are already unsubscribed. 

Additionally we need to figure out why people are trying to unsubscribe from something they are already unsubscribed from. Going to dig into if we are still sending messages to unsubscribed people. 

#### What are the relevant tickets?
Fixes  🐛 