### PR TITLE
add content-length header to api routes

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -32,6 +32,7 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
+            \Gladiator\Http\Middleware\AddContentLength::class,
             'throttle:60,1',
         ],
     ];

--- a/app/Http/Middleware/AddContentLength.php
+++ b/app/Http/Middleware/AddContentLength.php
@@ -3,6 +3,7 @@
 namespace Gladiator\Http\Middleware;
 
 use Closure;
+use Illuminate\Support\Str;
 
 class AddContentLength
 {
@@ -16,7 +17,7 @@ class AddContentLength
     public function handle($request, Closure $next)
     {
         $response = $next($request);
-        $response->header('Content-Length', strlen(serialize($response)));
+        $response->header('Content-Length', Str::length($response->getContent()));
 
         return $response;
     }

--- a/app/Http/Middleware/AddContentLength.php
+++ b/app/Http/Middleware/AddContentLength.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Gladiator\Http\Middleware;
+
+use Closure;
+
+class AddContentLength
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+        $response->header('Content-Length', strlen(serialize($response)));
+
+        return $response;
+    }
+}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -81,7 +81,7 @@ Route::group(['prefix' => 'api/v1'], function () {
     Route::post('unsubscribe', 'Api\UnsubscribeController@unsubscribe');
 });
 
-Route::group(['prefix' => 'api/v2'], function () {
+Route::group(['middleware' => ['api'], 'prefix' => 'api/v2'], function () {
     Route::get('/', function () {
         return 'Gladiator API version 2';
     });


### PR DESCRIPTION
#### What's this PR do?

Adds the `content-length` header to api responses.

#### How should this be manually tested?

Make an api request and see the `content-length` header in the set of response headers.

#### Any background context you want to provide?

Certain api requests were returning invalid JSON. 

For example, https://gladiator.dosomething.org/api/v2/contests?page=22 , returns invalid JSON.

I used https://jsonlint.com/ to validate the response object and it is invalid, returning this error:

```
Error: Parse error on line 154:
...d469c644e398bfa97", "588e90d2a0bfad499f5
-----------------------^
Expecting 'STRING', 'NUMBER', 'NULL', 'TRUE', 'FALSE', '{', '[', got 'undefined'
``` 

It looks like it is trying to return the over 2000 users in one of the competitions under the contest and it cuts off the response, making the response invalid JSON. Digging into why this might happen and it looks like if we set the `content-length` header on the response it will specify how long the body of the response should be. 

Open to other suggestions!

#### What are the relevant tickets?
Fixes https://www.pivotaltracker.com/story/show/150406511