### PR TITLE
use strlen() instead of Str::len

### DIFF
--- a/app/Http/Middleware/AddContentLength.php
+++ b/app/Http/Middleware/AddContentLength.php
@@ -3,7 +3,6 @@
 namespace Gladiator\Http\Middleware;
 
 use Closure;
-use Illuminate\Support\Str;
 
 class AddContentLength
 {
@@ -17,7 +16,7 @@ class AddContentLength
     public function handle($request, Closure $next)
     {
         $response = $next($request);
-        $response->header('Content-Length', Str::length($response->getContent()));
+        $response->header('Content-Length', strlen($response->getContent()));
 
         return $response;
     }


### PR DESCRIPTION
#### What's this PR do?
Uses `strlen()`  instead of `Str::len()` to get actual length of response in Bytes. 

#### How should this be manually tested?
Send a response, see the `content-length` header in the response. 
